### PR TITLE
[feature/#49] 상세 내부 이미지 및 투어 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RommieTextField.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RommieTextField.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -91,7 +92,7 @@ fun RommieTextField(
             decorationBox = { innerTextField ->
                 Row(
                     horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.Top
                 ) {
                     Box(
                         modifier = Modifier.weight(1f),
@@ -192,6 +193,14 @@ fun RoomieTextFieldPreview() {
                 onValueChange = {},
                 isValidate = false,
                 errorMessage = "에러메세지 동작 테스트"
+            )
+
+            RommieTextField(
+                paddingValues = PaddingValues(16.dp),
+                placeHolder = "문의내용을 적어주세요",
+                onValueChange = {},
+                textFieldValue = "",
+                modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.14).dp)
             )
         }
     }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieNavigateButton.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieNavigateButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wearerommies.roomie.R
+import com.wearerommies.roomie.presentation.core.extension.roomieButtonClickable
 import com.wearerommies.roomie.presentation.core.extension.roundedBackgroundWithBorder
 import com.wearerommies.roomie.presentation.type.NavigateButtonType
 import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
@@ -32,6 +33,7 @@ fun RoomieNavigateButton(
     modifier: Modifier = Modifier,
     textStyle: TextStyle = RoomieTheme.typography.body2Sb14,
     textColor: Color = RoomieTheme.colors.grayScale12,
+    pressedColor: Color = Color.Transparent,
     onClick: () -> Unit = {},
 ) {
     Row(
@@ -43,9 +45,10 @@ fun RoomieNavigateButton(
                 borderColor = type.borderColor,
                 borderWidth = type.borderWidth
             )
-            .clickable {
-                onClick()
-            }
+            .roomieButtonClickable(
+                onClick = onClick,
+                isPressed = true
+            )
             .padding(
                 type.paddingValues
             ),

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/extension/Modifier.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/extension/Modifier.kt
@@ -28,7 +28,7 @@ fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
 
 fun Modifier.roomieButtonClickable(
     onClick: () -> Unit,
-    pressedColor: Color,
+    pressedColor: Color = Color.Transparent,
     isPressed: Boolean = false,
 ): Modifier = composed {
     this

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailContentHeader.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailContentHeader.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -31,6 +30,7 @@ fun DetailContentHeader(
     contractTerm: Int,
     occupancyTypes: String,
     genderPolicy: String,
+    onClickDetailInnerButton: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -62,7 +62,9 @@ fun DetailContentHeader(
 
         Spacer(Modifier.height(36.dp))
 
-        DetailInnerImageButton()
+        DetailInnerImageButton(
+            onClickDetailInnerButton = onClickDetailInnerButton
+        )
     }
 }
 
@@ -128,7 +130,8 @@ fun DetailContentHeaderPreview() {
             occupancyStatus = "2/5",
             contractTerm = 3,
             occupancyTypes = "1,2인실",
-            genderPolicy = "여성 전용"
+            genderPolicy = "여성 전용",
+            onClickDetailInnerButton = {}
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailImagePager.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailImagePager.kt
@@ -1,0 +1,101 @@
+package com.wearerommies.roomie.presentation.ui.detail.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.wearerommies.roomie.R
+import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
+import com.wearerommies.roomie.ui.theme.RoomieTheme
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+fun DetailImagePager(
+    images: PersistentList<String>,
+    @StringRes contentDescription: Int,
+    modifier: Modifier = Modifier
+) {
+
+    val pagerState = rememberPagerState(
+        pageCount = { images.size }
+    )
+
+    HorizontalPager(
+        state = pagerState,
+
+        beyondViewportPageCount = 1,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp)),
+            contentAlignment = Alignment.BottomEnd
+        ) {
+            AsyncImage(
+                model = images[it],
+                contentDescription = stringResource(contentDescription),
+                modifier = Modifier
+                    .aspectRatio(360f / 312f),
+                contentScale = ContentScale.FillWidth
+            )
+
+            Text(
+                text = stringResource(
+                    id = R.string.detail_image_indicator,
+                    formatArgs = arrayOf((pagerState.currentPage + 1), images.size)
+                ),
+                color = RoomieTheme.colors.grayScale1,
+                style = RoomieTheme.typography.caption3M10,
+                modifier = Modifier
+                    .padding(
+                        end = 8.dp,
+                        bottom = 8.dp
+                    )
+                    .background(
+                        color = RoomieTheme.colors.transparentGray1250,
+                        shape = RoundedCornerShape(50.dp)
+                    )
+                    .padding(
+                        horizontal = 8.dp,
+                        vertical = 4.dp
+                    )
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DetailImagePagerPreview() {
+    RoomieAndroidTheme {
+        DetailImagePager(
+            images = persistentListOf(
+                "https://i.pravatar.cc/300",
+                "https://i.pravatar.cc/600"
+            ),
+            contentDescription = R.string.house_main_image,
+            modifier = Modifier
+                .padding(
+                    vertical = 8.dp,
+                    horizontal = 8.dp
+                )
+        )
+
+    }
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailInnerFacilityCard.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailInnerFacilityCard.kt
@@ -140,6 +140,24 @@ fun DetailInnerFacilityCardPreview() {
             )
 
             DetailInnerFacilityCard(
+                text = stringResource(R.string.room_kitchen_facility),
+                facility = persistentListOf(
+                    "세탁기",
+                    "건조기",
+                    "에어컨",
+                    "선풍기",
+                    "청소기",
+                    "소화전",
+                    "세탁용품",
+                    "전기장판",
+                    "빨래건조대",
+                    "스타일러"
+                ),
+                onClickExpandedButton = {},
+                isExpanded = false
+            )
+
+            DetailInnerFacilityCard(
                 text = "룸 A",
                 facility = persistentListOf(
                     "세탁기",
@@ -159,7 +177,7 @@ fun DetailInnerFacilityCardPreview() {
             )
 
             DetailInnerFacilityCard(
-                text = stringResource(R.string.room_kitchen_facility),
+                text = "룸 A",
                 facility = persistentListOf(
                     "세탁기",
                     "건조기",
@@ -173,7 +191,8 @@ fun DetailInnerFacilityCardPreview() {
                     "스타일러"
                 ),
                 onClickExpandedButton = {},
-                isExpanded = false
+                isExpanded = false,
+                roomStatus = false
             )
         }
     }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailInnerFacilityCard.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailInnerFacilityCard.kt
@@ -35,6 +35,7 @@ fun DetailInnerFacilityCard(
     onClickExpandedButton: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     isExpanded: Boolean = false,
+    roomStatus: Boolean = true,
     imageContent: @Composable () -> Unit = {},
 ) {
     Column(
@@ -66,6 +67,13 @@ fun DetailInnerFacilityCard(
                 color = RoomieTheme.colors.grayScale10,
                 modifier = Modifier.padding(start = 6.dp)
             )
+
+            if(!roomStatus){
+                DetailRoomInfoStatusChip(
+                    isAvailable = roomStatus,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
 
             Spacer(Modifier.weight(1f))
 
@@ -127,7 +135,27 @@ fun DetailInnerFacilityCardPreview() {
                     "스타일러"
                 ),
                 onClickExpandedButton = {},
-                isExpanded = true
+                isExpanded = true,
+                roomStatus = true
+            )
+
+            DetailInnerFacilityCard(
+                text = "룸 A",
+                facility = persistentListOf(
+                    "세탁기",
+                    "건조기",
+                    "에어컨",
+                    "선풍기",
+                    "청소기",
+                    "소화전",
+                    "세탁용품",
+                    "전기장판",
+                    "빨래건조대",
+                    "스타일러"
+                ),
+                onClickExpandedButton = {},
+                isExpanded = true,
+                roomStatus = false
             )
 
             DetailInnerFacilityCard(

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailInnerImageButton.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/component/DetailInnerImageButton.kt
@@ -10,15 +10,19 @@ import com.wearerommies.roomie.R
 import com.wearerommies.roomie.presentation.core.component.RoomieNavigateButton
 import com.wearerommies.roomie.presentation.type.NavigateButtonType
 import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
+import com.wearerommies.roomie.ui.theme.RoomieTheme
 
 @Composable
 fun DetailInnerImageButton(
+    onClickDetailInnerButton: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     RoomieNavigateButton(
         type = NavigateButtonType.DETAIL,
         text = stringResource(R.string.inner_image_button_text),
-        modifier = modifier
+        modifier = modifier,
+        onClick = onClickDetailInnerButton,
+        pressedColor = RoomieTheme.colors.grayScale2
     )
 }
 
@@ -27,7 +31,8 @@ fun DetailInnerImageButton(
 fun DetailInnerImageButtonPreview() {
     RoomieAndroidTheme {
         DetailInnerImageButton(
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(16.dp),
+            onClickDetailInnerButton = {}
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="roommate_sleep_time">수면시간</string>
     <string name="roommate_activity_time">활동시간</string>
     <string name="room_status_true">입주가능</string>
-    <string name="room_status_false">입주불가</string>
+    <string name="room_status_false">입주완료</string>
     <string name="room_type">방 형태</string>
     <string name="room_occupany_type">%d 인실</string>
     <string name="room_prepaid_utilities">선불공과금</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="room_safety_living_facility">안전 및 생활시설</string>
     <string name="room_kitchen_facility">주방시설</string>
     <string name="tour_apply">투어신청하기</string>
+    <string name="detail_image_indicator">%s / %s</string>
 
 
     // common


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 이다루미!! -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **🏠 ISSUE**

- #49 

## **❗ WORK DESCRIPTION**

- 상세보기 이미지 화면과 투어 화면에 관련된 뷰 컴포넌트 구현했습니다!
- 추가로 Navigation Button 컴포넌트 clickable Modifier 확장함수 사용으로 수정했습니다!
- textfield alignment 수정
- 확장 버튼 Chip 추가

## **📸 SCREENSHOT**

<!----필요한 친구들로 골라쓰루미!-->
**DetailInnerFacilityCard**
<img src="https://github.com/user-attachments/assets/852583a5-0888-4118-9d7b-a36196adff39" width="300" />

**DetailImagePager**
<video src="https://github.com/user-attachments/assets/8c1832cb-3ea8-429e-9697-952e9c7cbd87" width="300" /> 

## **📢 TO REVIEWERS**

- 공통컴포넌트 구두ㅇ로 이야기하고 건들이기는 했는데 재체크 한번씩만 부탁드립니다!
