### PR TITLE
[feature/#92] 상세 매물 navigation 연결

### DIFF
--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
@@ -52,7 +52,8 @@ fun RoomieNavHost(
         )
         bookmarkNavGraph(
             paddingValues = padding,
-            navigateUp = navigator::popBackStackIfNotHome
+            navigateUp = navigator::popBackStackIfNotHome,
+            navigateToDetail = navigator::navigateToDetail
         )
         filterNavGraph(
             paddingValues = padding,

--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
@@ -48,7 +48,8 @@ fun RoomieNavHost(
         )
         moodNavGraph(
             paddingValues = padding,
-            navigateUp = navigator::popBackStackIfNotHome
+            navigateUp = navigator::popBackStackIfNotHome,
+            navigateToDetail = navigator::navigateToDetail
         )
         bookmarkNavGraph(
             paddingValues = padding,

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/BookMarkRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/BookMarkRoute.kt
@@ -59,6 +59,7 @@ import kotlinx.collections.immutable.toPersistentList
 fun BookMarkRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
+    navigateToDetail: (Long) -> Unit,
     viewModel: BookMarkViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -85,6 +86,8 @@ fun BookMarkRoute(
                             duration = SnackbarDuration.Short
                         )
                     }
+
+                    is BookMarkSideEffect.NavigateToDetail -> navigateToDetail(sideEffect.houseId)
                 }
             }
     }
@@ -93,6 +96,7 @@ fun BookMarkRoute(
         paddingValues = paddingValues,
         snackBarHost = snackBarHost,
         navigateUp = navigateUp,
+        navigateToDetail = viewModel::navigateToDetail,
         onLikeClick = viewModel::bookmarkHouse,
         state = state.uiState
     )
@@ -104,6 +108,7 @@ fun BookMarkScreen(
     paddingValues: PaddingValues,
     snackBarHost: SnackbarHostState,
     navigateUp: () -> Unit,
+    navigateToDetail: (Long) -> Unit,
     state: EmptyUiState<List<RoomCardEntity>>,
     onLikeClick: (Long) -> Unit,
     modifier: Modifier = Modifier
@@ -239,9 +244,7 @@ fun BookMarkScreen(
                                 contractTerm = item.contractTerm,
                                 mainImgUrl = item.mainImgUrl
                             ),
-                            onClick = {
-                                //todo: 상세 매물 페이지로 이동
-                            },
+                            onClick = { navigateToDetail(item.houseId) },
                             onLikeClick = { onLikeClick(item.houseId) }
                         )
                     }
@@ -273,6 +276,7 @@ fun BookMarkScreenPreview() {
             paddingValues = PaddingValues(),
             snackBarHost = remember { SnackbarHostState() },
             navigateUp = {},
+            navigateToDetail = {},
             onLikeClick = {},
             state = EmptyUiState.Success(
                 listOf(

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/BookMarkSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/BookMarkSideEffect.kt
@@ -5,4 +5,5 @@ import androidx.annotation.StringRes
 sealed class BookMarkSideEffect {
     data class ShowToast(val message: String) : BookMarkSideEffect()
     data class SnackBar(@StringRes val message: Int) : BookMarkSideEffect()
+    data class NavigateToDetail(val houseId: Long) : BookMarkSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/BookMarkViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/BookMarkViewModel.kt
@@ -78,4 +78,12 @@ class BookMarkViewModel @Inject constructor(
                 Timber.e(error)
             }
     }
+
+    fun navigateToDetail(houseId: Long) = viewModelScope.launch {
+        _sideEffect.emit(
+            BookMarkSideEffect.NavigateToDetail(
+                houseId = houseId
+            )
+        )
+    }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/navigation/BookmarkNavigation.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/bookmark/navigation/BookmarkNavigation.kt
@@ -17,12 +17,14 @@ fun NavController.navigateToBookmark(navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.bookmarkNavGraph(
     paddingValues: PaddingValues,
-    navigateUp: () -> Unit
+    navigateUp: () -> Unit,
+    navigateToDetail: (Long) -> Unit
 ) {
     composable<Route.Bookmark> {
         BookMarkRoute(
             paddingValues = paddingValues,
-            navigateUp = navigateUp
+            navigateUp = navigateUp,
+            navigateToDetail = navigateToDetail
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/MoodRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/MoodRoute.kt
@@ -70,6 +70,7 @@ fun MoodRoute(
     moodTag: String,
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
+    navigateToDetail: (Long) -> Unit,
     viewModel: MoodViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -99,6 +100,8 @@ fun MoodRoute(
                             )
                         }
                     }
+
+                    is MoodSideEffect.NavigateToDetail -> navigateToDetail(sideEffect.houseId)
                 }
             }
     }
@@ -107,6 +110,7 @@ fun MoodRoute(
         paddingValues = paddingValues,
         snackBarHost = snackBarHost,
         navigateUp = navigateUp,
+        navigateToDetail = viewModel::navigateToDetail,
         moodTag = moodTag,
         onLikeClick = viewModel::bookmarkHouse,
         state = state.uiState
@@ -121,6 +125,7 @@ fun MoodScreen(
     snackBarHost: SnackbarHostState,
     moodTag: String,
     navigateUp: () -> Unit,
+    navigateToDetail: (Long) -> Unit,
     onLikeClick: (Long, String) -> Unit,
     state: UiState<MoodCardEntity>,
     modifier: Modifier = Modifier
@@ -286,9 +291,7 @@ fun MoodScreen(
                             contractTerm = item.contractTerm,
                             mainImgUrl = item.mainImgUrl
                         ),
-                        onClick = {
-                            //todo: 상세 페이지 이동
-                        },
+                        onClick = { navigateToDetail(item.houseId) },
                         onLikeClick = { onLikeClick(item.houseId, moodTag) }
                     )
                 }
@@ -365,6 +368,7 @@ fun MoodScreenPreview() {
             paddingValues = PaddingValues(),
             snackBarHost = remember { SnackbarHostState() },
             navigateUp = {},
+            navigateToDetail = {},
             onLikeClick = { _, _ -> },
             moodTag = "차분한",
             state = UiState.Success(

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/MoodSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/MoodSideEffect.kt
@@ -5,4 +5,5 @@ import androidx.annotation.StringRes
 sealed class MoodSideEffect {
     data class ShowToast(val message: String) : MoodSideEffect()
     data class SnackBar(@StringRes val message: Int) : MoodSideEffect()
+    data class NavigateToDetail(val houseId: Long) : MoodSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/MoodViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/MoodViewModel.kt
@@ -81,4 +81,12 @@ class MoodViewModel @Inject constructor(
             }
     }
 
+    fun navigateToDetail(houseId: Long) = viewModelScope.launch {
+        _sideEffect.emit(
+            MoodSideEffect.NavigateToDetail(
+                houseId = houseId
+            )
+        )
+    }
+
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/navigation/MoodNavigation.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mood/navigation/MoodNavigation.kt
@@ -20,14 +20,16 @@ fun NavController.navigateToMood(moodTag: String, navOptions: NavOptions? = null
 
 fun NavGraphBuilder.moodNavGraph(
     paddingValues: PaddingValues,
-    navigateUp: () -> Unit
+    navigateUp: () -> Unit,
+    navigateToDetail: (Long) -> Unit
 ) {
     composable<Route.Mood> { backStackEntry ->
         val moodTag = backStackEntry.toRoute<Route.Mood>().moodTag
         MoodRoute(
             paddingValues = paddingValues,
             moodTag = moodTag,
-            navigateUp = navigateUp
+            navigateUp = navigateUp,
+            navigateToDetail = navigateToDetail
         )
     }
 }


### PR DESCRIPTION
## **🏠 ISSUE**

- closed #92 

## **❗ WORK DESCRIPTION**

- 일부 뷰의 상세 매물 navigation을 연결했습니다.
    - 찜 리스트
    - 분위기 별 리스트

## **📸 SCREENSHOT**

- 찜 리스트

[bookmark_navigation.webm](https://github.com/user-attachments/assets/63ed34ad-9b32-4f07-a449-1aacf1e7c13c)

- 분위기 별 리스트

[mood_navigation.webm](https://github.com/user-attachments/assets/052e3dae-02df-4367-a00d-99b1517d1e10)


## **📢 TO REVIEWERS**

- 홈화면 코드보고 금방 연결했어유 샤라웃투예인
