### PR TITLE
[feature/#137] 온보딩에 자동 로그인 적용

### DIFF
--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainActivity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainActivity.kt
@@ -4,18 +4,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.wearerommies.roomie.presentation.ui.splash.SplashScreen
 import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -25,28 +15,12 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
-            var showSplash by remember { mutableStateOf(true) }
-            val counter by remember { mutableIntStateOf(0) }
-            val currentCounter by rememberUpdatedState(counter)
-
-            LaunchedEffect(currentCounter) {
-                delay(SPLASH_SCREEN_DELAY)
-                showSplash = false
-            }
 
             RoomieAndroidTheme {
-                if (showSplash) {
-                    SplashScreen()
-                } else {
-                    MainScreen(
-                        navigator = navigator
-                    )
-                }
+                MainScreen(
+                    navigator = navigator
+                )
             }
         }
-    }
-
-    companion object {
-        const val SPLASH_SCREEN_DELAY = 2000L
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainNavigator.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainNavigator.kt
@@ -39,7 +39,7 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Route.Onboarding
+    val startDestination = Route.Splash
 
     val currentTab: MainTabType?
         @Composable get() = MainTabType.find { tab ->

--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
@@ -36,7 +36,10 @@ fun RoomieNavHost(
         popEnterTransition = { EnterTransition.None },
         popExitTransition = { ExitTransition.None },
     ) {
-        splashNavGraph()
+        splashNavGraph(
+            navigateToOnboarding = navigator::navigateToOnboarding,
+            navigateToHome = navigator::navigateToHome
+        )
         loginNavGraph(
             paddingValues = padding,
             navigateUp = navigator::popBackStackIfNotHome,

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/login/LoginRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/login/LoginRoute.kt
@@ -47,12 +47,6 @@ fun LoginRoute(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val counter by remember { mutableIntStateOf(0) }
-    val currentCounter by rememberUpdatedState(counter)
-
-    LaunchedEffect(currentCounter) {
-        viewModel.checkAutoLogin()
-    }
 
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/login/LoginViewModel.kt
@@ -11,7 +11,6 @@ import com.wearerommies.roomie.domain.entity.SocialLoginEntity
 import com.wearerommies.roomie.domain.repository.AuthRepository
 import com.wearerommies.roomie.domain.repository.TokenRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -90,20 +89,7 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    fun checkAutoLogin() =
-        viewModelScope.launch {
-            delay(AUTO_LOGIN_DELAY)
-
-            _state.value.isLoggedIn = tokenRepository.getAccessToken().isNotEmpty()
-
-            if (_state.value.isLoggedIn) {
-                _sideEffect.emit(LoginSideEffect.LoginSuccess(tokenRepository.getAccessToken()))
-            }
-        }
-
-
     companion object {
         const val KAKAO = "KAKAO"
-        const val AUTO_LOGIN_DELAY = 50L
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashRoute.kt
@@ -7,6 +7,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -14,8 +19,44 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
 import com.wearerommies.roomie.R
 import com.wearerommies.roomie.ui.theme.RoomieTheme
+
+@Composable
+fun SplashRoute(
+    navigateToOnboarding: () -> Unit,
+    navigateToHome: () -> Unit,
+    viewModel: SplashViewModel = hiltViewModel()
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val counter by remember { mutableIntStateOf(0) }
+    val currentCounter by rememberUpdatedState(counter)
+
+    LaunchedEffect(currentCounter) {
+        viewModel.checkAutoLogin()
+    }
+
+    LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
+        viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
+            .collect { sideEffect ->
+                when (sideEffect) {
+                    is SplashSideEffect.NavigateToOnboarding -> {
+                        navigateToOnboarding()
+                    }
+
+                    is SplashSideEffect.NavigateToHome -> {
+                        navigateToHome()
+                    }
+                }
+            }
+    }
+
+    SplashScreen()
+}
+
 
 @Composable
 fun SplashScreen() {

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashSideEffect.kt
@@ -1,0 +1,6 @@
+package com.wearerommies.roomie.presentation.ui.splash
+
+sealed class SplashSideEffect {
+    data object NavigateToOnboarding : SplashSideEffect()
+    data class NavigateToHome(val accessToken: String) : SplashSideEffect()
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashState.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashState.kt
@@ -1,0 +1,5 @@
+package com.wearerommies.roomie.presentation.ui.splash
+
+data class SplashState(
+    var isLoggedIn: Boolean = false
+)

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/SplashViewModel.kt
@@ -1,0 +1,43 @@
+package com.wearerommies.roomie.presentation.ui.splash
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wearerommies.roomie.domain.repository.TokenRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val tokenRepository: TokenRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(SplashState())
+    val state: StateFlow<SplashState>
+        get() = _state
+
+    private val _sideEffect = MutableSharedFlow<SplashSideEffect>()
+    val sideEffect: SharedFlow<SplashSideEffect>
+        get() = _sideEffect
+
+    fun checkAutoLogin() =
+        viewModelScope.launch {
+            delay(SPLASH_SCREEN_DELAY)
+
+            _state.value.isLoggedIn = tokenRepository.getAccessToken().isNotEmpty()
+
+            if (_state.value.isLoggedIn) {
+                _sideEffect.emit(SplashSideEffect.NavigateToHome(tokenRepository.getAccessToken()))
+            } else
+                _sideEffect.emit(SplashSideEffect.NavigateToOnboarding)
+        }
+
+    companion object {
+        const val SPLASH_SCREEN_DELAY = 2000L
+    }
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/navigation/navigateToSplash.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/splash/navigation/navigateToSplash.kt
@@ -1,22 +1,18 @@
 package com.wearerommies.roomie.presentation.ui.splash.navigation
 
-import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.wearerommies.roomie.presentation.navigator.route.Route
-import com.wearerommies.roomie.presentation.ui.splash.SplashScreen
-
-fun NavController.navigateToSplash(navOptions: NavOptions? = null) {
-    navigate(
-        route = Route.Splash,
-        navOptions = navOptions
-    )
-}
+import com.wearerommies.roomie.presentation.ui.splash.SplashRoute
 
 fun NavGraphBuilder.splashNavGraph(
+    navigateToOnboarding: () -> Unit,
+    navigateToHome: () -> Unit
 ) {
     composable<Route.Splash> {
-        SplashScreen()
+        SplashRoute(
+            navigateToOnboarding = navigateToOnboarding,
+            navigateToHome = navigateToHome
+        )
     }
 }


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 이다루미!! -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **🏠 ISSUE**

- closed #137

## **❗ WORK DESCRIPTION**

- 수현씨 밥상에 숟가락 얹음

## **📸 SCREENSHOT**
https://github.com/user-attachments/assets/9822af69-f8a9-4fba-936c-0273b9c47e1b

## **💻 주요 코드**

- 로직 설명 -> start destination 을 splash 로 변경 -> splash 노출 시간동안 토큰 저장 여부 파악 -> 토큰 저장되어있다면 홈으로 저장되어있지 않다면 온보딩으로 이동
- 온보딩에서 판단하므로 기존 AUTO_LOGIN_DELAY 는 삭제하였어요!!

## **📢 TO REVIEWERS**

- 뀨
