### PR TITLE
[Feature/#142] 마이페이지 정보 수정 api 연동

### DIFF
--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
@@ -1,9 +1,11 @@
 package com.wearerommies.roomie.data.datasource
 
+import com.wearerommies.roomie.data.dto.request.RequestBirthDto
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
+import com.wearerommies.roomie.data.dto.response.ResponseBirthDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
@@ -28,4 +30,7 @@ internal class UserDataSource @Inject constructor(
 
     suspend fun editUserNickname(request: RequestNicknameDto): BaseResponse<ResponseNicknameDto> =
         userService.editUserNickname(request = request)
+
+    suspend fun editUserBirth(request: RequestBirthDto): BaseResponse<ResponseBirthDto> =
+        userService.editUserBirth(request = request)
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
@@ -1,11 +1,13 @@
 package com.wearerommies.roomie.data.datasource
 
 import com.wearerommies.roomie.data.dto.request.RequestBirthDto
+import com.wearerommies.roomie.data.dto.request.RequestContactDto
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseBirthDto
+import com.wearerommies.roomie.data.dto.response.ResponseContactDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
@@ -33,4 +35,7 @@ internal class UserDataSource @Inject constructor(
 
     suspend fun editUserBirth(request: RequestBirthDto): BaseResponse<ResponseBirthDto> =
         userService.editUserBirth(request = request)
+
+    suspend fun editUserContact(request: RequestContactDto): BaseResponse<ResponseContactDto> =
+        userService.editUserContact(request = request)
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
@@ -1,6 +1,7 @@
 package com.wearerommies.roomie.data.datasource
 
 import com.wearerommies.roomie.data.dto.response.BaseResponse
+import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.service.UserService
@@ -15,5 +16,7 @@ internal class UserDataSource @Inject constructor(
     suspend fun getUserInformation(): BaseResponse<ResponseMyPageDto> =
         userService.getUserInformation()
 
+    suspend fun getUserAccountInformation(): BaseResponse<ResponseAccountDto> =
+        userService.getUserAccountInformation()
 
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
@@ -2,12 +2,14 @@ package com.wearerommies.roomie.data.datasource
 
 import com.wearerommies.roomie.data.dto.request.RequestBirthDto
 import com.wearerommies.roomie.data.dto.request.RequestContactDto
+import com.wearerommies.roomie.data.dto.request.RequestGenderDto
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseBirthDto
 import com.wearerommies.roomie.data.dto.response.ResponseContactDto
+import com.wearerommies.roomie.data.dto.response.ResponseGenderDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
@@ -38,4 +40,7 @@ internal class UserDataSource @Inject constructor(
 
     suspend fun editUserContact(request: RequestContactDto): BaseResponse<ResponseContactDto> =
         userService.editUserContact(request = request)
+
+    suspend fun editUserGender(request: RequestGenderDto): BaseResponse<ResponseGenderDto> =
+        userService.editUserGender(request = request)
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
@@ -1,9 +1,11 @@
 package com.wearerommies.roomie.data.datasource
 
+import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
+import com.wearerommies.roomie.data.dto.response.ResponseNameDto
 import com.wearerommies.roomie.data.service.UserService
 import javax.inject.Inject
 
@@ -19,4 +21,6 @@ internal class UserDataSource @Inject constructor(
     suspend fun getUserAccountInformation(): BaseResponse<ResponseAccountDto> =
         userService.getUserAccountInformation()
 
+    suspend fun editUserName(request: RequestNameDto): BaseResponse<ResponseNameDto> =
+        userService.editUserName(request = request)
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/UserDataSource.kt
@@ -1,11 +1,13 @@
 package com.wearerommies.roomie.data.datasource
 
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
+import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
+import com.wearerommies.roomie.data.dto.response.ResponseNicknameDto
 import com.wearerommies.roomie.data.service.UserService
 import javax.inject.Inject
 
@@ -23,4 +25,7 @@ internal class UserDataSource @Inject constructor(
 
     suspend fun editUserName(request: RequestNameDto): BaseResponse<ResponseNameDto> =
         userService.editUserName(request = request)
+
+    suspend fun editUserNickname(request: RequestNicknameDto): BaseResponse<ResponseNicknameDto> =
+        userService.editUserNickname(request = request)
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestBirthDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestBirthDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.request
+
+import com.wearerommies.roomie.domain.entity.BirthEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestBirthDto(
+    @SerialName("birthDay")
+    val birthDay: String
+)
+
+fun BirthEntity.toDto() = RequestBirthDto(
+    birthDay = birthDay
+)

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestContactDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestContactDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.request
+
+import com.wearerommies.roomie.domain.entity.ContactEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestContactDto(
+    @SerialName("phoneNumber")
+    val phoneNumber: String
+)
+
+fun ContactEntity.toDto() = RequestContactDto(
+    phoneNumber = phoneNumber
+)

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestGenderDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestGenderDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.request
+
+import com.wearerommies.roomie.domain.entity.GenderEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestGenderDto(
+    @SerialName("gender")
+    val gender: String
+)
+
+fun GenderEntity.toDto() = RequestGenderDto(
+    gender = gender
+)

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestNameDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestNameDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.request
+
+import com.wearerommies.roomie.domain.entity.NameEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestNameDto(
+    @SerialName("name")
+    val name: String
+)
+
+fun NameEntity.toDto() = RequestNameDto(
+    name = name
+)

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestNicknameDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/request/RequestNicknameDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.request
+
+import com.wearerommies.roomie.domain.entity.NicknameEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestNicknameDto(
+    @SerialName("nickname")
+    val nickname: String
+)
+
+fun NicknameEntity.toDto() = RequestNicknameDto(
+    nickname = nickname
+)

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseAccountDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseAccountDto.kt
@@ -1,0 +1,30 @@
+package com.wearerommies.roomie.data.dto.response
+
+import com.wearerommies.roomie.domain.entity.AccountEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseAccountDto(
+    @SerialName("birthDate")
+    val birthDate: String?,
+    @SerialName("gender")
+    val gender: String?,
+    @SerialName("name")
+    val name: String?,
+    @SerialName("nickname")
+    val nickname: String?,
+    @SerialName("phoneNumber")
+    val phoneNumber: String?,
+    @SerialName("socialType")
+    val socialType: String?
+) {
+    fun toEntity() = AccountEntity(
+        birthDate = birthDate,
+        gender = gender,
+        name = name,
+        nickname = nickname,
+        phoneNumber = phoneNumber,
+        socialType = socialType
+    )
+}

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseBirthDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseBirthDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.response
+
+import com.wearerommies.roomie.domain.entity.BirthEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseBirthDto(
+    @SerialName("birthDay")
+    val birthDay: String
+) {
+    fun toEntity() = BirthEntity(
+        birthDay = birthDay
+    )
+}

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseContactDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseContactDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.response
+
+import com.wearerommies.roomie.domain.entity.ContactEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseContactDto(
+    @SerialName("phoneNumber")
+    val phoneNumber: String
+) {
+    fun toEntity() = ContactEntity(
+        phoneNumber = phoneNumber
+    )
+}

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseGenderDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseGenderDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.response
+
+import com.wearerommies.roomie.domain.entity.GenderEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseGenderDto(
+    @SerialName("gender")
+    val gender: String
+) {
+    fun toEntity() = GenderEntity(
+        gender = gender
+    )
+}

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseMyPageDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseMyPageDto.kt
@@ -1,16 +1,18 @@
 package com.wearerommies.roomie.data.dto.response
 
-
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ResponseMyPageDto(
-    @SerialName("name")
-    val name: String
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("socialType")
+    val socialType: String
 ) {
     fun toEntity() = MyPageEntity(
-        name = name
+        nickname = nickname,
+        socialType = socialType
     )
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseNameDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseNameDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.response
+
+import com.wearerommies.roomie.domain.entity.NameEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseNameDto(
+    @SerialName("name")
+    val name: String
+) {
+    fun toEntity() = NameEntity(
+        name = name
+    )
+}

--- a/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseNicknameDto.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/dto/response/ResponseNicknameDto.kt
@@ -1,0 +1,15 @@
+package com.wearerommies.roomie.data.dto.response
+
+import com.wearerommies.roomie.domain.entity.NicknameEntity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseNicknameDto(
+    @SerialName("nickname")
+    val nickname: String
+) {
+    fun toEntity() = NicknameEntity(
+        nickname = nickname
+    )
+}

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.wearerommies.roomie.data.repositoryimpl
 import com.wearerommies.roomie.data.datasource.UserDataSource
 import com.wearerommies.roomie.data.dto.request.toDto
 import com.wearerommies.roomie.domain.entity.AccountEntity
+import com.wearerommies.roomie.domain.entity.BirthEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
@@ -36,5 +37,10 @@ internal class UserRepositoryImpl @Inject constructor(
     override suspend fun editUserNickname(nickname: NicknameEntity): Result<NicknameEntity> =
         runCatching {
             userDataSource.editUserNickname(request = nickname.toDto()).data.toEntity()
+        }
+
+    override suspend fun editUserBirth(birthDay: BirthEntity): Result<BirthEntity> =
+        runCatching {
+            userDataSource.editUserBirth(request = birthDay.toDto()).data.toEntity()
         }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.wearerommies.roomie.data.repositoryimpl
 
 import com.wearerommies.roomie.data.datasource.UserDataSource
+import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
@@ -17,5 +18,10 @@ internal class UserRepositoryImpl @Inject constructor(
     override suspend fun getUserInformation(): Result<MyPageEntity> =
         runCatching {
             userDataSource.getUserInformation().data.toEntity()
+        }
+
+    override suspend fun getUserAccountInformation(): Result<AccountEntity> =
+        runCatching {
+            userDataSource.getUserAccountInformation().data.toEntity()
         }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
@@ -1,9 +1,11 @@
 package com.wearerommies.roomie.data.repositoryimpl
 
 import com.wearerommies.roomie.data.datasource.UserDataSource
+import com.wearerommies.roomie.data.dto.request.toDto
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
+import com.wearerommies.roomie.domain.entity.NameEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
 import javax.inject.Inject
 
@@ -23,5 +25,10 @@ internal class UserRepositoryImpl @Inject constructor(
     override suspend fun getUserAccountInformation(): Result<AccountEntity> =
         runCatching {
             userDataSource.getUserAccountInformation().data.toEntity()
+        }
+
+    override suspend fun editUserName(name: NameEntity): Result<NameEntity> =
+        runCatching {
+            userDataSource.editUserName(request = name.toDto()).data.toEntity()
         }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.wearerommies.roomie.data.dto.request.toDto
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.BirthEntity
 import com.wearerommies.roomie.domain.entity.ContactEntity
+import com.wearerommies.roomie.domain.entity.GenderEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
@@ -48,5 +49,10 @@ internal class UserRepositoryImpl @Inject constructor(
     override suspend fun editUserContact(phoneNumber: ContactEntity): Result<ContactEntity> =
         runCatching {
             userDataSource.editUserContact(request = phoneNumber.toDto()).data.toEntity()
+        }
+
+    override suspend fun editUserGender(gender: GenderEntity): Result<GenderEntity> =
+        runCatching {
+            userDataSource.editUserGender(request = gender.toDto()).data.toEntity()
         }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.wearerommies.roomie.data.datasource.UserDataSource
 import com.wearerommies.roomie.data.dto.request.toDto
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.BirthEntity
+import com.wearerommies.roomie.domain.entity.ContactEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
@@ -42,5 +43,10 @@ internal class UserRepositoryImpl @Inject constructor(
     override suspend fun editUserBirth(birthDay: BirthEntity): Result<BirthEntity> =
         runCatching {
             userDataSource.editUserBirth(request = birthDay.toDto()).data.toEntity()
+        }
+
+    override suspend fun editUserContact(phoneNumber: ContactEntity): Result<ContactEntity> =
+        runCatching {
+            userDataSource.editUserContact(request = phoneNumber.toDto()).data.toEntity()
         }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
+import com.wearerommies.roomie.domain.entity.NicknameEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
 import javax.inject.Inject
 
@@ -30,5 +31,10 @@ internal class UserRepositoryImpl @Inject constructor(
     override suspend fun editUserName(name: NameEntity): Result<NameEntity> =
         runCatching {
             userDataSource.editUserName(request = name.toDto()).data.toEntity()
+        }
+
+    override suspend fun editUserNickname(nickname: NicknameEntity): Result<NicknameEntity> =
+        runCatching {
+            userDataSource.editUserNickname(request = nickname.toDto()).data.toEntity()
         }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
@@ -2,12 +2,14 @@ package com.wearerommies.roomie.data.service
 
 import com.wearerommies.roomie.data.dto.request.RequestBirthDto
 import com.wearerommies.roomie.data.dto.request.RequestContactDto
+import com.wearerommies.roomie.data.dto.request.RequestGenderDto
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseBirthDto
 import com.wearerommies.roomie.data.dto.response.ResponseContactDto
+import com.wearerommies.roomie.data.dto.response.ResponseGenderDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
@@ -45,4 +47,9 @@ interface UserService {
     suspend fun editUserContact(
         @Body request: RequestContactDto
     ): BaseResponse<ResponseContactDto>
+
+    @PATCH("/v1/users/gender")
+    suspend fun editUserGender(
+        @Body request: RequestGenderDto
+    ): BaseResponse<ResponseGenderDto>
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
@@ -1,9 +1,11 @@
 package com.wearerommies.roomie.data.service
 
+import com.wearerommies.roomie.data.dto.request.RequestBirthDto
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
+import com.wearerommies.roomie.data.dto.response.ResponseBirthDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
@@ -31,4 +33,9 @@ interface UserService {
     suspend fun editUserNickname(
         @Body request: RequestNicknameDto
     ): BaseResponse<ResponseNicknameDto>
+
+    @PATCH("/v1/users/birthday")
+    suspend fun editUserBirth(
+        @Body request: RequestBirthDto
+    ): BaseResponse<ResponseBirthDto>
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
@@ -1,11 +1,13 @@
 package com.wearerommies.roomie.data.service
 
 import com.wearerommies.roomie.data.dto.request.RequestBirthDto
+import com.wearerommies.roomie.data.dto.request.RequestContactDto
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseBirthDto
+import com.wearerommies.roomie.data.dto.response.ResponseContactDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
@@ -38,4 +40,9 @@ interface UserService {
     suspend fun editUserBirth(
         @Body request: RequestBirthDto
     ): BaseResponse<ResponseBirthDto>
+
+    @PATCH("/v1/users/phonenumber")
+    suspend fun editUserContact(
+        @Body request: RequestContactDto
+    ): BaseResponse<ResponseContactDto>
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
@@ -1,11 +1,13 @@
 package com.wearerommies.roomie.data.service
 
 import com.wearerommies.roomie.data.dto.request.RequestNameDto
+import com.wearerommies.roomie.data.dto.request.RequestNicknameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import com.wearerommies.roomie.data.dto.response.ResponseNameDto
+import com.wearerommies.roomie.data.dto.response.ResponseNicknameDto
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -24,4 +26,9 @@ interface UserService {
     suspend fun editUserName(
         @Body request: RequestNameDto
     ): BaseResponse<ResponseNameDto>
+
+    @PATCH("/v1/users/nickname")
+    suspend fun editUserNickname(
+        @Body request: RequestNicknameDto
+    ): BaseResponse<ResponseNicknameDto>
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.wearerommies.roomie.data.service
 
 import com.wearerommies.roomie.data.dto.response.BaseResponse
+import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
 import retrofit2.http.GET
@@ -11,4 +12,7 @@ interface UserService {
 
     @GET("/v1/users/mypage")
     suspend fun getUserInformation(): BaseResponse<ResponseMyPageDto>
+
+    @GET("/v1/users/mypage/accountinfo")
+    suspend fun getUserAccountInformation(): BaseResponse<ResponseAccountDto>
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/UserService.kt
@@ -1,10 +1,14 @@
 package com.wearerommies.roomie.data.service
 
+import com.wearerommies.roomie.data.dto.request.RequestNameDto
 import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseAccountDto
 import com.wearerommies.roomie.data.dto.response.ResponseHomeDto
 import com.wearerommies.roomie.data.dto.response.ResponseMyPageDto
+import com.wearerommies.roomie.data.dto.response.ResponseNameDto
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 
 interface UserService {
     @GET("/v1/users/home")
@@ -15,4 +19,9 @@ interface UserService {
 
     @GET("/v1/users/mypage/accountinfo")
     suspend fun getUserAccountInformation(): BaseResponse<ResponseAccountDto>
+
+    @PATCH("/v1/users/name")
+    suspend fun editUserName(
+        @Body request: RequestNameDto
+    ): BaseResponse<ResponseNameDto>
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/entity/AccountEntity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/entity/AccountEntity.kt
@@ -1,0 +1,10 @@
+package com.wearerommies.roomie.domain.entity
+
+data class AccountEntity(
+    val birthDate: String?,
+    val gender: String?,
+    val name: String?,
+    val nickname: String?,
+    val phoneNumber: String?,
+    val socialType: String?
+)

--- a/app/src/main/java/com/wearerommies/roomie/domain/entity/BirthEntity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/entity/BirthEntity.kt
@@ -1,0 +1,5 @@
+package com.wearerommies.roomie.domain.entity
+
+data class BirthEntity(
+    val birthDay: String
+)

--- a/app/src/main/java/com/wearerommies/roomie/domain/entity/ContactEntity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/entity/ContactEntity.kt
@@ -1,0 +1,5 @@
+package com.wearerommies.roomie.domain.entity
+
+data class ContactEntity(
+    val phoneNumber: String
+)

--- a/app/src/main/java/com/wearerommies/roomie/domain/entity/GenderEntity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/entity/GenderEntity.kt
@@ -1,0 +1,5 @@
+package com.wearerommies.roomie.domain.entity
+
+data class GenderEntity(
+    val gender: String
+)

--- a/app/src/main/java/com/wearerommies/roomie/domain/entity/MyPageEntity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/entity/MyPageEntity.kt
@@ -1,5 +1,6 @@
 package com.wearerommies.roomie.domain.entity
 
 data class MyPageEntity(
-    val name: String
+    val nickname: String,
+    val socialType: String
 )

--- a/app/src/main/java/com/wearerommies/roomie/domain/entity/NameEntity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/entity/NameEntity.kt
@@ -1,0 +1,5 @@
+package com.wearerommies.roomie.domain.entity
+
+data class NameEntity(
+    val name: String
+)

--- a/app/src/main/java/com/wearerommies/roomie/domain/entity/NicknameEntity.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/entity/NicknameEntity.kt
@@ -1,0 +1,5 @@
+package com.wearerommies.roomie.domain.entity
+
+data class NicknameEntity(
+    val nickname: String
+)

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
@@ -4,10 +4,12 @@ import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
+import com.wearerommies.roomie.domain.entity.NicknameEntity
 
 interface UserRepository {
     suspend fun getHomeData(): Result<HomeDataEntity>
     suspend fun getUserInformation(): Result<MyPageEntity>
     suspend fun getUserAccountInformation(): Result<AccountEntity>
     suspend fun editUserName(name: NameEntity): Result<NameEntity>
+    suspend fun editUserNickname(nickname: NicknameEntity): Result<NicknameEntity>
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
@@ -2,6 +2,7 @@ package com.wearerommies.roomie.domain.repository
 
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.BirthEntity
+import com.wearerommies.roomie.domain.entity.ContactEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
@@ -14,4 +15,5 @@ interface UserRepository {
     suspend fun editUserName(name: NameEntity): Result<NameEntity>
     suspend fun editUserNickname(nickname: NicknameEntity): Result<NicknameEntity>
     suspend fun editUserBirth(birthDay: BirthEntity): Result<BirthEntity>
+    suspend fun editUserContact(phoneNumber: ContactEntity): Result<ContactEntity>
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
@@ -3,6 +3,7 @@ package com.wearerommies.roomie.domain.repository
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.BirthEntity
 import com.wearerommies.roomie.domain.entity.ContactEntity
+import com.wearerommies.roomie.domain.entity.GenderEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
@@ -16,4 +17,5 @@ interface UserRepository {
     suspend fun editUserNickname(nickname: NicknameEntity): Result<NicknameEntity>
     suspend fun editUserBirth(birthDay: BirthEntity): Result<BirthEntity>
     suspend fun editUserContact(phoneNumber: ContactEntity): Result<ContactEntity>
+    suspend fun editUserGender(gender: GenderEntity): Result<GenderEntity>
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.wearerommies.roomie.domain.repository
 
 import com.wearerommies.roomie.domain.entity.AccountEntity
+import com.wearerommies.roomie.domain.entity.BirthEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 import com.wearerommies.roomie.domain.entity.NameEntity
@@ -12,4 +13,5 @@ interface UserRepository {
     suspend fun getUserAccountInformation(): Result<AccountEntity>
     suspend fun editUserName(name: NameEntity): Result<NameEntity>
     suspend fun editUserNickname(nickname: NicknameEntity): Result<NicknameEntity>
+    suspend fun editUserBirth(birthDay: BirthEntity): Result<BirthEntity>
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
@@ -3,9 +3,11 @@ package com.wearerommies.roomie.domain.repository
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
+import com.wearerommies.roomie.domain.entity.NameEntity
 
 interface UserRepository {
     suspend fun getHomeData(): Result<HomeDataEntity>
     suspend fun getUserInformation(): Result<MyPageEntity>
     suspend fun getUserAccountInformation(): Result<AccountEntity>
+    suspend fun editUserName(name: NameEntity): Result<NameEntity>
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/UserRepository.kt
@@ -1,9 +1,11 @@
 package com.wearerommies.roomie.domain.repository
 
+import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.entity.HomeDataEntity
 import com.wearerommies.roomie.domain.entity.MyPageEntity
 
 interface UserRepository {
     suspend fun getHomeData(): Result<HomeDataEntity>
     suspend fun getUserInformation(): Result<MyPageEntity>
+    suspend fun getUserAccountInformation(): Result<AccountEntity>
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieDatePicker.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieDatePicker.kt
@@ -28,14 +28,16 @@ const val UTC: String = "UTC"
 fun RoomieDatePicker(
     onConfirm: (selectedDateMillis: Long?) -> Unit,
     onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
     inLimited: Boolean = true,
-    modifier: Modifier = Modifier
+    birthLimited: Boolean = false
 ) {
     DatePickerModal(
         onConfirm = onConfirm,
         onDismiss = onDismiss,
         inLimited = inLimited,
-        modifier = modifier
+        modifier = modifier,
+        birthLimited = birthLimited
     )
 }
 
@@ -45,27 +47,29 @@ fun DatePickerModal(
     onConfirm: (Long?) -> Unit,
     onDismiss: () -> Unit,
     inLimited: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    birthLimited: Boolean = false,
 ) {
-    val todayMillisUtc = LocalDate.now().atStartOfDay(ZoneOffset.UTC)?.toInstant()?.toEpochMilli() ?: System.currentTimeMillis()
+    val todayMillisUtc = LocalDate.now().atStartOfDay(ZoneOffset.UTC)?.toInstant()?.toEpochMilli()
+        ?: System.currentTimeMillis()
 
     val datePickerState = rememberDatePickerState(
         initialSelectedDateMillis = todayMillisUtc,
         selectableDates = object : SelectableDates {
             override fun isSelectableDate(utcTimeMillis: Long): Boolean {
-                return if (inLimited) {
-                    utcTimeMillis >= todayMillisUtc
-                } else {
-                    true
+                return when {
+                    birthLimited -> utcTimeMillis <= todayMillisUtc
+                    inLimited -> utcTimeMillis >= todayMillisUtc
+                    else -> true
                 }
             }
 
             override fun isSelectableYear(year: Int): Boolean {
-                return if (inLimited) {
-                    val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-                    year >= currentYear
-                } else {
-                    true
+                val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+                return when {
+                    birthLimited -> year <= currentYear
+                    inLimited -> year >= currentYear
+                    else -> true
                 }
             }
         }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/util/GenderFormatter.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/util/GenderFormatter.kt
@@ -1,0 +1,11 @@
+package com.wearerommies.roomie.presentation.core.util
+
+import com.wearerommies.roomie.presentation.type.GenderType
+
+fun formatGender(input: String): String {
+    return when (input) {
+        GenderType.MALE.name -> "남성"
+        GenderType.FEMALE.name -> "여성"
+        else -> ""
+    }
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/util/PhoneNumberFormatter.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/util/PhoneNumberFormatter.kt
@@ -1,0 +1,12 @@
+package com.wearerommies.roomie.presentation.core.util
+
+fun formatPhoneNumber(input: String): String {
+    val digits = input.filter { it.isDigit() }
+
+    return when {
+        digits.length <= 3 -> digits
+        digits.length <= 7 -> "${digits.substring(0, 3)}-${digits.substring(3)}"
+        digits.length <= 11 -> "${digits.substring(0, 3)}-${digits.substring(3, 7)}-${digits.substring(7)}"
+        else -> "${digits.substring(0, 3)}-${digits.substring(3, 7)}-${digits.substring(7, 11)}"
+    }
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/type/GenderType.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/type/GenderType.kt
@@ -2,5 +2,7 @@ package com.wearerommies.roomie.presentation.type
 
 enum class GenderType(val value: String) {
     MAN("남성"),
-    WOMAN("여성")
+    WOMAN("여성"),
+    MALE("남성"),
+    FEMALE("여성")
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthRoute.kt
@@ -28,6 +28,7 @@ import com.wearerommies.roomie.presentation.ui.mypage.component.MyEditButton
 import com.wearerommies.roomie.presentation.ui.mypage.component.MyTopBar
 import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
 import com.wearerommies.roomie.ui.theme.RoomieTheme
+import timber.log.Timber
 
 @Composable
 fun BirthRoute(
@@ -49,6 +50,9 @@ fun BirthRoute(
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
+                when (sideEffect) {
+                    BirthSideEffect.NavigateUp -> navigateUp()
+                }
             }
     }
 
@@ -59,7 +63,7 @@ fun BirthRoute(
         state = state,
         onBirthdateChanged = viewModel::updateBirthdate,
         updateDateModalState = viewModel::updateBirthDateModalState,
-        onClickEditButton = {}
+        onClickEditButton = viewModel::editUserBirth
     )
 
 }
@@ -78,6 +82,7 @@ fun BirthScreen(
     if (state.isShowBirthDateModal)
         RoomieDatePicker(
             onConfirm = { date ->
+                Timber.tag("birth").d("birth: ${state.birth}, updatedBirth: ${state.updatedBirth}")
                 onBirthdateChanged(date)
                 updateDateModalState()
             },

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthRoute.kt
@@ -90,7 +90,8 @@ fun BirthScreen(
                 updateDateModalState()
             },
             modifier = Modifier.padding(horizontal = 36.dp),
-            inLimited = false
+            inLimited = false,
+            birthLimited = true
         )
 
     Column(

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthSideEffect.kt
@@ -1,4 +1,5 @@
 package com.wearerommies.roomie.presentation.ui.mypage.birth
 
 sealed class BirthSideEffect {
+    data object NavigateUp : BirthSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthState.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthState.kt
@@ -5,5 +5,5 @@ data class BirthState(
     val updatedBirth: String = "",
     val isShowBirthDateModal: Boolean = false,
 ) {
-    val isEnabled = birth.isNotEmpty() && birth != updatedBirth
+    val isEnabled = updatedBirth.isNotEmpty() && birth != updatedBirth
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/birth/BirthViewModel.kt
@@ -2,7 +2,9 @@ package com.wearerommies.roomie.presentation.ui.mypage.birth
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wearerommies.roomie.domain.entity.BirthEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
+import com.wearerommies.roomie.presentation.core.util.toFormattedDto
 import com.wearerommies.roomie.presentation.core.util.toFormattedString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -12,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.Date
 import javax.inject.Inject
 
@@ -40,7 +43,7 @@ class BirthViewModel @Inject constructor(
         _state.value = _state.value.copy(
             updatedBirth = birthdate?.let {
                 Date(birthdate).toFormattedString()
-            } ?: "",
+            }?.toFormattedDto() ?: "",
         )
     }
 
@@ -48,5 +51,27 @@ class BirthViewModel @Inject constructor(
         _state.value = _state.value.copy(
             isShowBirthDateModal = !_state.value.isShowBirthDateModal
         )
+    }
+
+    fun navigateUp() = viewModelScope.launch {
+        _sideEffect.emit(BirthSideEffect.NavigateUp)
+    }
+
+    fun editUserBirth() = viewModelScope.launch {
+        userRepository.editUserBirth(
+            birthDay = BirthEntity(
+                birthDay = state.value.updatedBirth
+            )
+        )
+            .onSuccess { response ->
+                _state.value = _state.value.copy(
+                    birth = response.birthDay,
+                    updatedBirth = response.birthDay
+                )
+                navigateUp()
+            }
+            .onFailure { error ->
+                Timber.e(error)
+            }
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/component/MyButton.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/component/MyButton.kt
@@ -45,10 +45,10 @@ fun MyGenderButton(
     updatedGender: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    genderType: String = GenderType.MAN.value
+    genderType: String = GenderType.MALE.name
 ) {
     RoomieButton(
-        text = if (genderType == GenderType.MAN.value)
+        text = if (genderType == GenderType.MALE.name)
             stringResource(R.string.man)
         else
             stringResource(R.string.woman),

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/contact/ContactRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/contact/ContactRoute.kt
@@ -50,6 +50,9 @@ fun ContactRoute(
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
+                when(sideEffect) {
+                    ContactSideEffect.NavigateUp -> navigateUp()
+                }
             }
     }
 
@@ -59,7 +62,7 @@ fun ContactRoute(
         navigateUp = navigateUp,
         state = state,
         onPhoneNumberChanged = viewModel::updatePhoneNumber,
-        onClickEditButton = {}
+        onClickEditButton = viewModel::editUserContact
     )
 
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/contact/ContactSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/contact/ContactSideEffect.kt
@@ -1,4 +1,5 @@
 package com.wearerommies.roomie.presentation.ui.mypage.contact
 
 sealed class ContactSideEffect {
+    data object NavigateUp : ContactSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/contact/ContactViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/contact/ContactViewModel.kt
@@ -1,6 +1,8 @@
 package com.wearerommies.roomie.presentation.ui.mypage.contact
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wearerommies.roomie.domain.entity.ContactEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
 import com.wearerommies.roomie.presentation.core.util.RegexConstants.PHONE_NUMBER_REGEX
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,6 +12,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,10 +40,29 @@ class ContactViewModel @Inject constructor(
     fun updatePhoneNumber(phoneNumber: String) {
         _state.value = _state.value.copy(
             updatedPhoneNumber = phoneNumber,
-        )
-
-        _state.value = _state.value.copy(
             isValidated = PHONE_NUMBER_REGEX.matches(phoneNumber)
         )
+    }
+
+    fun navigateUp() = viewModelScope.launch {
+        _sideEffect.emit(ContactSideEffect.NavigateUp)
+    }
+
+    fun editUserContact() = viewModelScope.launch {
+        userRepository.editUserContact(
+            phoneNumber = ContactEntity(
+                phoneNumber = state.value.updatedPhoneNumber
+            )
+        )
+            .onSuccess { response ->
+                _state.value = _state.value.copy(
+                    phoneNumber = response.phoneNumber,
+                    updatedPhoneNumber = response.phoneNumber
+                )
+                navigateUp()
+            }
+            .onFailure { error ->
+                Timber.e(error)
+            }
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/gender/GenderRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/gender/GenderRoute.kt
@@ -51,6 +51,9 @@ fun GenderRoute(
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
+                when (sideEffect) {
+                    GenderSideEffect.NavigateUp -> navigateUp()
+                }
             }
     }
 
@@ -60,7 +63,7 @@ fun GenderRoute(
         navigateUp = navigateUp,
         state = state,
         onClickGenderButton = viewModel::updateGender,
-        onClickEditButton = {}
+        onClickEditButton = viewModel::editUserGender
     )
 
 }
@@ -98,17 +101,17 @@ fun GenderScreen(
             MyGenderButton(
                 updatedGender = state.updatedGender,
                 onClick = {
-                    onClickGenderButton(GenderType.MAN.value)
+                    onClickGenderButton(GenderType.MALE.name)
                 },
                 modifier = Modifier
                     .weight(1f),
             )
 
             MyGenderButton(
-                genderType = GenderType.WOMAN.value,
+                genderType = GenderType.FEMALE.name,
                 updatedGender = state.updatedGender,
                 onClick = {
-                    onClickGenderButton(GenderType.WOMAN.value)
+                    onClickGenderButton(GenderType.FEMALE.name)
                 },
                 modifier = Modifier
                     .weight(1f),

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/gender/GenderSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/gender/GenderSideEffect.kt
@@ -1,4 +1,5 @@
 package com.wearerommies.roomie.presentation.ui.mypage.gender
 
 sealed class GenderSideEffect {
+    data object NavigateUp : GenderSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/gender/GenderViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/gender/GenderViewModel.kt
@@ -1,6 +1,8 @@
 package com.wearerommies.roomie.presentation.ui.mypage.gender
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wearerommies.roomie.domain.entity.GenderEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -9,6 +11,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,5 +40,27 @@ class GenderViewModel @Inject constructor(
         _state.value = _state.value.copy(
             updatedGender = gender,
         )
+    }
+
+    fun navigateUp() = viewModelScope.launch {
+        _sideEffect.emit(GenderSideEffect.NavigateUp)
+    }
+
+    fun editUserGender() = viewModelScope.launch {
+        userRepository.editUserGender(
+            gender = GenderEntity(
+                gender = state.value.updatedGender
+            )
+        )
+            .onSuccess { response ->
+                _state.value = _state.value.copy(
+                    gender = response.gender,
+                    updatedGender = response.gender
+                )
+                navigateUp()
+            }
+            .onFailure { error ->
+                Timber.e(error)
+            }
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyRoute.kt
@@ -115,7 +115,7 @@ fun MyScreen(
                         color = RoomieTheme.colors.grayScale4
                     ),
                 profileImgUrl = "",
-                nickname = state.name,
+                nickname = state.nickname,
                 onClick = navigateToMyAccount
             )
 
@@ -194,7 +194,8 @@ fun MyScreenPreview() {
             navigateToMyAccount = {},
             navigateToBookmark = {},
             state = MyPageEntity(
-                name = "루미"
+                nickname = "루미",
+                socialType = "KAKAO"
             )
         )
     }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyState.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyState.kt
@@ -4,6 +4,7 @@ import com.wearerommies.roomie.domain.entity.MyPageEntity
 
 data class MyState(
     val uiState: MyPageEntity = MyPageEntity(
-        name = "닉네임"
+        nickname = "닉네임",
+        socialType = "KAKAO"
     )
 )

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyViewModel.kt
@@ -34,7 +34,8 @@ class MyViewModel @Inject constructor(
             .onSuccess { response ->
                 _state.value = _state.value.copy(
                     uiState = MyPageEntity(
-                        name = response.name
+                        nickname = response.nickname,
+                        socialType = response.socialType
                     )
                 )
             }.onFailure { error ->

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.wearerommies.roomie.R
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.presentation.core.component.RoomieButton
+import com.wearerommies.roomie.presentation.core.util.formatPhoneNumber
 import com.wearerommies.roomie.presentation.type.MyAccountType
 import com.wearerommies.roomie.presentation.ui.mypage.component.MyTopBar
 import com.wearerommies.roomie.presentation.ui.mypage.myaccount.component.MyAccountButton
@@ -137,7 +138,7 @@ fun MyAccountScreen(
             )
             MyAccountButton(
                 myAccountType = MyAccountType.PHONE_NUMBER,
-                userInformation = state.phoneNumber.orEmpty(),
+                userInformation = formatPhoneNumber(state.phoneNumber.orEmpty()),
                 onClick = { navigateToContact(state.phoneNumber.orEmpty()) },
             )
 

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.wearerommies.roomie.R
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.presentation.core.component.RoomieButton
+import com.wearerommies.roomie.presentation.core.util.formatGender
 import com.wearerommies.roomie.presentation.core.util.formatPhoneNumber
 import com.wearerommies.roomie.presentation.type.MyAccountType
 import com.wearerommies.roomie.presentation.ui.mypage.component.MyTopBar
@@ -133,7 +134,7 @@ fun MyAccountScreen(
             )
             MyAccountButton(
                 myAccountType = MyAccountType.GENDER,
-                userInformation = state.gender.orEmpty(),
+                userInformation = formatGender(state.gender.orEmpty()),
                 onClick = { navigateToGender(state.gender.orEmpty()) },
             )
             MyAccountButton(

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -192,7 +192,8 @@ fun MyAccountScreenPreview() {
             paddingValues = PaddingValues(),
             navigateUp = {},
             state = MyPageEntity(
-                name = "루미"
+                nickname = "루미",
+                socialType = "KAKAO"
             ),
             navigateToName = {},
             navigateToNickname = {},

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -28,7 +28,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.wearerommies.roomie.R
-import com.wearerommies.roomie.domain.entity.MyPageEntity
+import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.presentation.core.component.RoomieButton
 import com.wearerommies.roomie.presentation.type.MyAccountType
 import com.wearerommies.roomie.presentation.ui.mypage.component.MyTopBar
@@ -55,7 +55,7 @@ fun MyAccountRoute(
     val currentCounter by rememberUpdatedState(counter)
 
     LaunchedEffect(currentCounter) {
-        viewModel.getUserInformation()
+        viewModel.getUserAccountInformation()
     }
 
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
@@ -93,7 +93,7 @@ fun MyAccountScreen(
     navigateToBirth: (String) -> Unit,
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
-    state: MyPageEntity,
+    state: AccountEntity,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -117,28 +117,28 @@ fun MyAccountScreen(
 
             MyAccountButton(
                 myAccountType = MyAccountType.NAME,
-                userInformation = "이루미",
-                onClick = { navigateToName("이루미") },
+                userInformation = state.name.orEmpty(),
+                onClick = { navigateToName(state.name.orEmpty()) },
             )
             MyAccountButton(
                 myAccountType = MyAccountType.NICKNAME,
-                userInformation = "카드값줘체리",
-                onClick = { navigateToNickname("카드값줘체리") },
+                userInformation = state.nickname.orEmpty(),
+                onClick = { navigateToNickname(state.nickname.orEmpty()) },
             )
             MyAccountButton(
                 myAccountType = MyAccountType.BIRTH,
-                userInformation = "2025.03.21",
-                onClick = { navigateToBirth("2025.03.21") },
+                userInformation = state.birthDate.orEmpty(),
+                onClick = { navigateToBirth(state.birthDate.orEmpty()) },
             )
             MyAccountButton(
                 myAccountType = MyAccountType.GENDER,
-                userInformation = "여성",
-                onClick = { navigateToGender("여성") },
+                userInformation = state.gender.orEmpty(),
+                onClick = { navigateToGender(state.gender.orEmpty()) },
             )
             MyAccountButton(
                 myAccountType = MyAccountType.PHONE_NUMBER,
-                userInformation = "010-0000-0000",
-                onClick = { navigateToContact("010-0000-0000") },
+                userInformation = state.phoneNumber.orEmpty(),
+                onClick = { navigateToContact(state.phoneNumber.orEmpty()) },
             )
 
             Spacer(
@@ -191,9 +191,13 @@ fun MyAccountScreenPreview() {
         MyAccountScreen(
             paddingValues = PaddingValues(),
             navigateUp = {},
-            state = MyPageEntity(
+            state = AccountEntity(
                 nickname = "루미",
-                socialType = "KAKAO"
+                socialType = "KAKAO",
+                birthDate = "",
+                gender = "",
+                name = "",
+                phoneNumber = ""
             ),
             navigateToName = {},
             navigateToNickname = {},

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountState.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountState.kt
@@ -4,6 +4,7 @@ import com.wearerommies.roomie.domain.entity.MyPageEntity
 
 data class MyAccountState(
     val uiState: MyPageEntity = MyPageEntity(
-        name = "닉네임"
+        nickname = "닉네임",
+        socialType = "KAKAO"
     )
 )

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountState.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountState.kt
@@ -1,10 +1,14 @@
 package com.wearerommies.roomie.presentation.ui.mypage.myaccount
 
-import com.wearerommies.roomie.domain.entity.MyPageEntity
+import com.wearerommies.roomie.domain.entity.AccountEntity
 
 data class MyAccountState(
-    val uiState: MyPageEntity = MyPageEntity(
+    val uiState: AccountEntity = AccountEntity(
         nickname = "닉네임",
-        socialType = "KAKAO"
+        socialType = "KAKAO",
+        birthDate = "",
+        gender = "",
+        name = "",
+        phoneNumber = ""
     )
 )

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
@@ -34,7 +34,8 @@ class MyAccountViewModel @Inject constructor(
             .onSuccess { response ->
                 _state.value = _state.value.copy(
                     uiState = MyPageEntity(
-                        name = response.name
+                        nickname = response.nickname,
+                        socialType = response.socialType
                     )
                 )
             }.onFailure { error ->

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
@@ -2,7 +2,7 @@ package com.wearerommies.roomie.presentation.ui.mypage.myaccount
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wearerommies.roomie.domain.entity.MyPageEntity
+import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -29,13 +29,17 @@ class MyAccountViewModel @Inject constructor(
     val sideEffect: SharedFlow<MyAccountSideEffect>
         get() = _sideEffect.asSharedFlow()
 
-    suspend fun getUserInformation() {
-        userRepository.getUserInformation()
+    suspend fun getUserAccountInformation() {
+        userRepository.getUserAccountInformation()
             .onSuccess { response ->
                 _state.value = _state.value.copy(
-                    uiState = MyPageEntity(
+                    uiState = AccountEntity(
                         nickname = response.nickname,
-                        socialType = response.socialType
+                        socialType = response.socialType,
+                        birthDate = response.birthDate,
+                        gender = response.gender,
+                        name = response.name,
+                        phoneNumber = response.phoneNumber
                     )
                 )
             }.onFailure { error ->

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/name/NameRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/name/NameRoute.kt
@@ -50,6 +50,9 @@ fun NameRoute(
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
+                when (sideEffect) {
+                    NameSideEffect.NavigateUp -> navigateUp()
+                }
 
             }
     }
@@ -60,7 +63,7 @@ fun NameRoute(
         navigateUp = navigateUp,
         state = state,
         onNameChanged = viewModel::updateName,
-        onClickEditButton = {}
+        onClickEditButton = viewModel::editUserName
     )
 }
 

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/name/NameSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/name/NameSideEffect.kt
@@ -1,4 +1,5 @@
 package com.wearerommies.roomie.presentation.ui.mypage.name
 
 sealed class NameSideEffect {
+    data object NavigateUp : NameSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/name/NameViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/name/NameViewModel.kt
@@ -1,6 +1,8 @@
 package com.wearerommies.roomie.presentation.ui.mypage.name
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wearerommies.roomie.domain.entity.NameEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
 import com.wearerommies.roomie.presentation.core.util.RegexConstants.NAME_REGEX
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,6 +12,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -41,5 +45,27 @@ class NameViewModel @Inject constructor(
         _state.value = _state.value.copy(
             isValidated = NAME_REGEX.matches(name)
         )
+    }
+
+    fun navigateUp() = viewModelScope.launch {
+        _sideEffect.emit(NameSideEffect.NavigateUp)
+    }
+
+    fun editUserName() = viewModelScope.launch {
+        userRepository.editUserName(
+            name = NameEntity(
+                name = state.value.updatedName
+            )
+        )
+            .onSuccess { response ->
+                _state.value = _state.value.copy(
+                    name = response.name,
+                    updatedName = response.name
+                )
+                navigateUp()
+            }
+            .onFailure { error ->
+                Timber.e(error)
+            }
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/nickname/NicknameRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/nickname/NicknameRoute.kt
@@ -50,7 +50,9 @@ fun NicknameRoute(
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
-
+                when(sideEffect) {
+                    NicknameSideEffect.NavigateUp -> navigateUp()
+                }
             }
     }
 
@@ -60,7 +62,7 @@ fun NicknameRoute(
         navigateUp = navigateUp,
         state = state,
         onNicknameChanged = viewModel::updateNickname,
-        onClickEditButton = {}
+        onClickEditButton = viewModel::editUserNickname
     )
 
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/nickname/NicknameSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/nickname/NicknameSideEffect.kt
@@ -1,4 +1,5 @@
 package com.wearerommies.roomie.presentation.ui.mypage.nickname
 
 sealed class NicknameSideEffect {
+    data object NavigateUp : NicknameSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/nickname/NicknameViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/nickname/NicknameViewModel.kt
@@ -1,6 +1,8 @@
 package com.wearerommies.roomie.presentation.ui.mypage.nickname
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wearerommies.roomie.domain.entity.NicknameEntity
 import com.wearerommies.roomie.domain.repository.UserRepository
 import com.wearerommies.roomie.presentation.core.util.RegexConstants.NICK_NAME_REGEX
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,6 +12,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -41,5 +45,27 @@ class NicknameViewModel @Inject constructor(
         _state.value = _state.value.copy(
             isValidated = NICK_NAME_REGEX.matches(nickname)
         )
+    }
+
+    fun navigateUp() = viewModelScope.launch {
+        _sideEffect.emit(NicknameSideEffect.NavigateUp)
+    }
+
+    fun editUserNickname() = viewModelScope.launch {
+        userRepository.editUserNickname(
+            nickname = NicknameEntity(
+                nickname = state.value.updatedNickname
+            )
+        )
+            .onSuccess { response ->
+                _state.value = _state.value.copy(
+                    nickname = response.nickname,
+                    updatedNickname = response.nickname
+                )
+                navigateUp()
+            }
+            .onFailure { error ->
+                Timber.e(error)
+            }
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/second/TourSecondStepRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/second/TourSecondStepRoute.kt
@@ -110,7 +110,8 @@ fun TourSecondStepScreen(
                 updateDateModalState()
             },
             modifier = Modifier.padding(horizontal = 36.dp),
-            inLimited = false
+            inLimited = false,
+            birthLimited = true
         )
 
     Column(


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 이다루미!! -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **🏠 ISSUE**

- closed #142 

## **❗ WORK DESCRIPTION**

- 마이페이지 정보 조회 api 연동
   - 마이페이지 수정된 dto 적용
   - 계정 정보 조회 api 연동

- 마이페이지 정보 수정 api 연동
   - 이름
   - 닉네임
   - 생년월일
   - 성별
   - 연락처

## **📸 SCREENSHOT**

마이페이지 | 나의 계정 정보 
  :--: | :--:
  <img src="https://github.com/user-attachments/assets/63dd594b-2b2f-448c-aa07-7cb5d0a86fd9" width="300" /> | <img src="https://github.com/user-attachments/assets/5d39b345-b46e-4cbb-9609-7de16074636c" width="300" >

[이름.webm](https://github.com/user-attachments/assets/63481412-b7b6-4c86-bd22-792c3002cab1)

[닉네임.webm](https://github.com/user-attachments/assets/7d7ada06-ae6e-4da7-a0e9-4381f950c2a5)

[생년월일.webm](https://github.com/user-attachments/assets/24b8d081-9c1c-46c1-a1b9-1285bb8c84e9)

[성별.webm](https://github.com/user-attachments/assets/f8f6157f-2f46-408f-b1b6-4ee2c210fa9f)

[연락처.webm](https://github.com/user-attachments/assets/9af4fa08-0c76-41c3-8e5a-90d7966b671d)


## **💻 주요 코드**

Gender 수정 시, FEMALE 또는 MALE로 보내줘야하는데 기존 GenderType에는 MAN 또는 WOMAN으로 구성되어있길래 관련 중요 로직이 있을까봐 일단 수정하지않고 FEMALE과 MALE을 새로 추가해줬습니다! 혹시 통일해도 괜찮으면 알려주세여

## **📢 TO REVIEWERS**

