### PR TITLE
[feature/#148] 로그아웃, 회원탈퇴 구현

### DIFF
--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/AuthDataSource.kt
@@ -18,4 +18,7 @@ class AuthDataSource @Inject constructor(
 
     suspend fun deleteLogout(refreshToken: String) =
         authService.deleteLogout(refreshToken = refreshToken)
+
+    suspend fun deleteWithdraw(refreshToken: String) =
+        authService.deleteWithdraw(refreshToken = refreshToken)
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/datasource/AuthDataSource.kt
@@ -15,4 +15,7 @@ class AuthDataSource @Inject constructor(
 
     suspend fun postTokenReissue(refreshToken: String): BaseResponse<ResponseReissueTokenDto> =
         authService.postTokenReissue(refreshToken = refreshToken)
+
+    suspend fun deleteLogout(refreshToken: String) =
+        authService.deleteLogout(refreshToken = refreshToken)
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -29,4 +29,9 @@ internal class AuthRepositoryImpl @Inject constructor(
         runCatching {
             authDataSource.deleteLogout(refreshToken = refreshToken)
         }
+
+    override suspend fun deleteWithdraw(refreshToken: String): Result<Unit> =
+        runCatching {
+            authDataSource.deleteWithdraw(refreshToken = refreshToken)
+        }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -24,4 +24,9 @@ internal class AuthRepositoryImpl @Inject constructor(
                 refreshToken = refreshToken
             ).data.toEntity()
         }
+
+    override suspend fun deleteLogout(refreshToken: String) =
+        runCatching {
+            authDataSource.deleteLogout(refreshToken = refreshToken)
+        }
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -25,7 +25,7 @@ internal class AuthRepositoryImpl @Inject constructor(
             ).data.toEntity()
         }
 
-    override suspend fun deleteLogout(refreshToken: String) =
+    override suspend fun deleteLogout(refreshToken: String): Result<Unit> =
         runCatching {
             authDataSource.deleteLogout(refreshToken = refreshToken)
         }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/AuthService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/AuthService.kt
@@ -24,4 +24,9 @@ interface AuthService {
     suspend fun deleteLogout(
         @Header("Authorization") refreshToken: String
     )
+
+    @DELETE("/v1/users/delete")
+    suspend fun deleteWithdraw(
+        @Header("Authorization") refreshToken: String
+    )
 }

--- a/app/src/main/java/com/wearerommies/roomie/data/service/AuthService.kt
+++ b/app/src/main/java/com/wearerommies/roomie/data/service/AuthService.kt
@@ -5,6 +5,7 @@ import com.wearerommies.roomie.data.dto.response.BaseResponse
 import com.wearerommies.roomie.data.dto.response.ResponseReissueTokenDto
 import com.wearerommies.roomie.data.dto.response.ResponseTokenDto
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.Header
 import retrofit2.http.POST
 
@@ -18,4 +19,9 @@ interface AuthService {
     suspend fun postTokenReissue(
         @Header("Authorization") refreshToken: String
     ): BaseResponse<ResponseReissueTokenDto>
+
+    @DELETE("/v1/auth/oauth/logout")
+    suspend fun deleteLogout(
+        @Header("Authorization") refreshToken: String
+    )
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/AuthRepository.kt
@@ -8,4 +8,5 @@ interface AuthRepository {
     suspend fun postSocialLogin(loginData: SocialLoginEntity): Result<TokenEntity>
     suspend fun postTokenReissue(refreshToken: String): Result<ReissueTokenEntity>
     suspend fun deleteLogout(refreshToken: String): Result<Unit>
+    suspend fun deleteWithdraw(refreshToken: String): Result<Unit>
 }

--- a/app/src/main/java/com/wearerommies/roomie/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/wearerommies/roomie/domain/repository/AuthRepository.kt
@@ -7,4 +7,5 @@ import com.wearerommies.roomie.domain.entity.TokenEntity
 interface AuthRepository {
     suspend fun postSocialLogin(loginData: SocialLoginEntity): Result<TokenEntity>
     suspend fun postTokenReissue(refreshToken: String): Result<ReissueTokenEntity>
+    suspend fun deleteLogout(refreshToken: String): Result<Unit>
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieButton.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieButton.kt
@@ -36,6 +36,7 @@ fun RoomieButton(
     borderColor: Color = Color.Transparent,
     borderWidth: Dp = 0.dp,
     verticalPadding: Dp = 18.dp,
+    horizontalPadding: Dp = 0.dp,
     textStyle: TextStyle = RoomieTheme.typography.title2Sb16
 ) {
     Text(
@@ -53,7 +54,7 @@ fun RoomieButton(
             .run {
                 if (isEnabled) clickable(onClick = onClick) else this
             }
-            .padding(vertical = verticalPadding)
+            .padding(vertical = verticalPadding, horizontal = horizontalPadding)
 
     )
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieDialog.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieDialog.kt
@@ -1,0 +1,16 @@
+package com.wearerommies.roomie.presentation.core.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.Dialog
+
+@Composable
+fun RoomieDialog(
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieTwoButtonDialog.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieTwoButtonDialog.kt
@@ -1,0 +1,124 @@
+package com.wearerommies.roomie.presentation.core.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.wearerommies.roomie.presentation.core.extension.roundedBackgroundWithBorder
+import com.wearerommies.roomie.presentation.type.TwoButtonDialogType
+import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
+import com.wearerommies.roomie.ui.theme.RoomieTheme
+
+@Composable
+fun RoomieTwoButtonDialog(
+    twoButtonDialogType: TwoButtonDialogType,
+    onDismissRequest: () -> Unit,
+    onClickConfirm: () -> Unit,
+    onClickDismiss: () -> Unit,
+) {
+    RoomieDialog(
+        onDismissRequest = onDismissRequest
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .roundedBackgroundWithBorder(
+                    cornerRadius = 8.dp,
+                    backgroundColor = RoomieTheme.colors.grayScale1,
+                )
+                .padding(horizontal = 16.dp, vertical = 14.dp)
+        ) {
+            Text(
+                text = stringResource(twoButtonDialogType.titleRes),
+                style = RoomieTheme.typography.body6M12,
+                color = Color.Black
+            )
+
+            Spacer(
+                modifier = Modifier.height(32.dp)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp, alignment = Alignment.End),
+            ) {
+                RoomieButton(
+                    verticalPadding = 8.dp,
+                    horizontalPadding = 16.dp,
+                    text = stringResource(twoButtonDialogType.dismissButtonTextRes),
+                    textStyle = RoomieTheme.typography.body5Sb12,
+                    textColor = Color.Black,
+                    backgroundColor = RoomieTheme.colors.grayScale4,
+                    onClick = onClickDismiss,
+                )
+                RoomieButton(
+                    verticalPadding = 8.dp,
+                    horizontalPadding = 16.dp,
+                    text = stringResource(twoButtonDialogType.confirmButtonTextRes),
+                    textStyle = RoomieTheme.typography.body5Sb12,
+                    textColor = RoomieTheme.colors.grayScale1,
+                    backgroundColor = RoomieTheme.colors.primary,
+                    onClick = onClickConfirm,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RoomieTwoButtonDialogPreview() {
+    val showTwoButtonDialog = remember { mutableStateOf(false) }
+
+    RoomieAndroidTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = RoomieTheme.colors.grayScale1),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            RoomieButton(
+                text = "클릭",
+                backgroundColor = RoomieTheme.colors.primary,
+                textColor = RoomieTheme.colors.grayScale1,
+                onClick = {
+                    showTwoButtonDialog.value = true
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(all = 20.dp),
+                pressedColor = RoomieTheme.colors.primaryLight1
+            )
+        }
+
+        if (showTwoButtonDialog.value) {
+            RoomieTwoButtonDialog(
+                twoButtonDialogType = TwoButtonDialogType.WITHDRAW,
+                onDismissRequest = {
+                    showTwoButtonDialog.value = false
+                },
+                onClickConfirm = {
+                    showTwoButtonDialog.value = false
+                },
+                onClickDismiss = {
+                    showTwoButtonDialog.value = false
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/util/GenderFormatter.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/util/GenderFormatter.kt
@@ -1,11 +1,12 @@
 package com.wearerommies.roomie.presentation.core.util
 
+import com.wearerommies.roomie.presentation.core.util.UserConstants.NO_DATA
 import com.wearerommies.roomie.presentation.type.GenderType
 
 fun formatGender(input: String): String {
     return when (input) {
         GenderType.MALE.name -> "남성"
         GenderType.FEMALE.name -> "여성"
-        else -> ""
+        else -> NO_DATA
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/util/PhoneNumberFormatter.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/util/PhoneNumberFormatter.kt
@@ -1,9 +1,12 @@
 package com.wearerommies.roomie.presentation.core.util
 
+import com.wearerommies.roomie.presentation.core.util.UserConstants.NO_DATA
+
 fun formatPhoneNumber(input: String): String {
     val digits = input.filter { it.isDigit() }
 
     return when {
+        digits.isEmpty() -> NO_DATA
         digits.length <= 3 -> digits
         digits.length <= 7 -> "${digits.substring(0, 3)}-${digits.substring(3)}"
         digits.length <= 11 -> "${digits.substring(0, 3)}-${digits.substring(3, 7)}-${digits.substring(7)}"

--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/util/UserConstants.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/util/UserConstants.kt
@@ -1,0 +1,5 @@
+package com.wearerommies.roomie.presentation.core.util
+
+object UserConstants {
+    val NO_DATA = "정보없음"
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainNavigator.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainNavigator.kt
@@ -26,9 +26,9 @@ import com.wearerommies.roomie.presentation.ui.mood.navigation.navigateToMood
 import com.wearerommies.roomie.presentation.ui.mypage.birth.navigation.navigateToBirth
 import com.wearerommies.roomie.presentation.ui.mypage.contact.navigation.navigateToContact
 import com.wearerommies.roomie.presentation.ui.mypage.gender.navigation.navigateToGender
+import com.wearerommies.roomie.presentation.ui.mypage.my.navigation.navigateToMy
 import com.wearerommies.roomie.presentation.ui.mypage.myaccount.navigation.navigateToMyAccount
 import com.wearerommies.roomie.presentation.ui.mypage.name.navigation.navigateToName
-import com.wearerommies.roomie.presentation.ui.mypage.my.navigation.navigateToMy
 import com.wearerommies.roomie.presentation.ui.mypage.nickname.navigation.navigateToNickname
 import com.wearerommies.roomie.presentation.ui.onboarding.navigation.navigateToOnboarding
 import com.wearerommies.roomie.presentation.ui.search.navigation.navigateToSearch
@@ -99,7 +99,14 @@ class MainNavigator(
     }
 
     fun navigateToLogin() {
-        navController.navigateToLogin()
+        navController.navigateToLogin(
+            navOptions = navOptions {
+                popUpTo(0) {
+                    inclusive = true
+                }
+                launchSingleTop = true
+            }
+        )
     }
 
     fun navigateToMap(filter: FilterEntity, result: SearchResultEntity) {

--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
@@ -19,9 +19,9 @@ import com.wearerommies.roomie.presentation.ui.mood.navigation.moodNavGraph
 import com.wearerommies.roomie.presentation.ui.mypage.birth.navigation.birthNavGraph
 import com.wearerommies.roomie.presentation.ui.mypage.contact.navigation.contactNavGraph
 import com.wearerommies.roomie.presentation.ui.mypage.gender.navigation.genderNavGraph
+import com.wearerommies.roomie.presentation.ui.mypage.my.navigation.myNavGraph
 import com.wearerommies.roomie.presentation.ui.mypage.myaccount.navigation.myAccountNavGraph
 import com.wearerommies.roomie.presentation.ui.mypage.name.navigation.nameNavGraph
-import com.wearerommies.roomie.presentation.ui.mypage.my.navigation.myNavGraph
 import com.wearerommies.roomie.presentation.ui.mypage.nickname.navigation.nicknameNavGraph
 import com.wearerommies.roomie.presentation.ui.onboarding.navigation.onboardingNavGraph
 import com.wearerommies.roomie.presentation.ui.search.navigation.searchNavGraph
@@ -89,7 +89,8 @@ fun RoomieNavHost(
             navigateToName = navigator::navigateToName,
             navigateToBirth = navigator::navigateToBirth,
             navigateToGender = navigator::navigateToGender,
-            navigateToContact = navigator::navigateToContact
+            navigateToContact = navigator::navigateToContact,
+            navigateToLogin = navigator::navigateToLogin
         )
         nameNavGraph(
             paddingValues = padding,

--- a/app/src/main/java/com/wearerommies/roomie/presentation/type/TwoButtonDialogType.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/type/TwoButtonDialogType.kt
@@ -1,0 +1,21 @@
+package com.wearerommies.roomie.presentation.type
+
+import androidx.annotation.StringRes
+import com.wearerommies.roomie.R
+
+enum class TwoButtonDialogType(
+    @StringRes val titleRes: Int,
+    @StringRes val confirmButtonTextRes: Int,
+    @StringRes val dismissButtonTextRes: Int
+) {
+    LOGOUT(
+        titleRes = R.string.logout_dialog_title,
+        confirmButtonTextRes = R.string.confirm,
+        dismissButtonTextRes = R.string.dismiss
+    ),
+    WITHDRAW(
+        titleRes = R.string.withdraw_dialog_title,
+        confirmButtonTextRes = R.string.withdraw,
+        dismissButtonTextRes = R.string.withdraw_dismiss
+    )
+}

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -47,6 +47,7 @@ fun MyAccountRoute(
     navigateToBirth: (String) -> Unit,
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
+    navigateToLogin: () -> Unit,
     viewModel: MyAccountViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -69,6 +70,7 @@ fun MyAccountRoute(
                     is MyAccountSideEffect.NavigateToContact -> navigateToContact(sideEffect.contact)
                     is MyAccountSideEffect.NavigateToGender -> navigateToGender(sideEffect.gender)
                     is MyAccountSideEffect.NavigateToName -> navigateToName(sideEffect.name)
+                    is MyAccountSideEffect.NavigateToLogin -> navigateToLogin()
                 }
             }
     }
@@ -82,6 +84,8 @@ fun MyAccountRoute(
         navigateToBirth = viewModel::navigateToBirth,
         navigateToGender = viewModel::navigateToGender,
         navigateToContact = viewModel::navigateToContact,
+        deleteLogout = viewModel::deleteLogout
+
     )
 }
 
@@ -95,6 +99,7 @@ fun MyAccountScreen(
     navigateToBirth: (String) -> Unit,
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
+    deleteLogout: () -> Unit,
     state: AccountEntity,
     modifier: Modifier = Modifier
 ) {
@@ -161,9 +166,7 @@ fun MyAccountScreen(
                 backgroundColor = RoomieTheme.colors.grayScale1,
                 textColor = RoomieTheme.colors.grayScale7,
                 textStyle = RoomieTheme.typography.body2Sb14,
-                onClick = {
-                    //todo: logout
-                },
+                onClick = deleteLogout,
                 borderColor = RoomieTheme.colors.grayScale5,
                 borderWidth = 1.dp
             )
@@ -206,6 +209,7 @@ fun MyAccountScreenPreview() {
             navigateToBirth = {},
             navigateToGender = {},
             navigateToContact = {},
+            deleteLogout = {}
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -84,7 +84,8 @@ fun MyAccountRoute(
         navigateToBirth = viewModel::navigateToBirth,
         navigateToGender = viewModel::navigateToGender,
         navigateToContact = viewModel::navigateToContact,
-        deleteLogout = viewModel::deleteLogout
+        deleteLogout = viewModel::deleteLogout,
+        deleteWithdraw = viewModel::deleteWithdraw
 
     )
 }
@@ -100,6 +101,7 @@ fun MyAccountScreen(
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
     deleteLogout: () -> Unit,
+    deleteWithdraw: () -> Unit,
     state: AccountEntity,
     modifier: Modifier = Modifier
 ) {
@@ -174,7 +176,7 @@ fun MyAccountScreen(
             Text(
                 modifier = Modifier
                     .clickable {
-                        //todo: withdraw
+                       deleteWithdraw()
                     }
                     .padding(horizontal = 4.dp),
                 text = stringResource(R.string.withdraw),
@@ -209,7 +211,8 @@ fun MyAccountScreenPreview() {
             navigateToBirth = {},
             navigateToGender = {},
             navigateToContact = {},
-            deleteLogout = {}
+            deleteLogout = {},
+            deleteWithdraw = {}
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -30,9 +30,11 @@ import androidx.lifecycle.flowWithLifecycle
 import com.wearerommies.roomie.R
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.presentation.core.component.RoomieButton
+import com.wearerommies.roomie.presentation.core.component.RoomieTwoButtonDialog
 import com.wearerommies.roomie.presentation.core.util.formatGender
 import com.wearerommies.roomie.presentation.core.util.formatPhoneNumber
 import com.wearerommies.roomie.presentation.type.MyAccountType
+import com.wearerommies.roomie.presentation.type.TwoButtonDialogType
 import com.wearerommies.roomie.presentation.ui.mypage.component.MyTopBar
 import com.wearerommies.roomie.presentation.ui.mypage.myaccount.component.MyAccountButton
 import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
@@ -79,14 +81,17 @@ fun MyAccountRoute(
         paddingValues = paddingValues,
         navigateUp = navigateUp,
         state = state.uiState,
+        isShowLogoutDialog = state.isShowLogoutDialog,
+        isShowWithdrawDialog = state.isShowWithdrawDialog,
         navigateToName = viewModel::navigateToName,
         navigateToNickname = viewModel::navigateToNickname,
         navigateToBirth = viewModel::navigateToBirth,
         navigateToGender = viewModel::navigateToGender,
         navigateToContact = viewModel::navigateToContact,
         deleteLogout = viewModel::deleteLogout,
-        deleteWithdraw = viewModel::deleteWithdraw
-
+        deleteWithdraw = viewModel::deleteWithdraw,
+        updateLogoutDialog = viewModel::updateLogoutDialogState,
+        updateWithdrawDialog = viewModel::updateWithdrawDialogState
     )
 }
 
@@ -100,9 +105,13 @@ fun MyAccountScreen(
     navigateToBirth: (String) -> Unit,
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
+    updateLogoutDialog: () -> Unit,
+    updateWithdrawDialog: () -> Unit,
     deleteLogout: () -> Unit,
     deleteWithdraw: () -> Unit,
     state: AccountEntity,
+    isShowLogoutDialog: Boolean,
+    isShowWithdrawDialog: Boolean,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -168,7 +177,7 @@ fun MyAccountScreen(
                 backgroundColor = RoomieTheme.colors.grayScale1,
                 textColor = RoomieTheme.colors.grayScale7,
                 textStyle = RoomieTheme.typography.body2Sb14,
-                onClick = deleteLogout,
+                onClick = updateLogoutDialog,
                 borderColor = RoomieTheme.colors.grayScale5,
                 borderWidth = 1.dp
             )
@@ -176,7 +185,7 @@ fun MyAccountScreen(
             Text(
                 modifier = Modifier
                     .clickable {
-                       deleteWithdraw()
+                        updateWithdrawDialog()
                     }
                     .padding(horizontal = 4.dp),
                 text = stringResource(R.string.withdraw),
@@ -188,6 +197,24 @@ fun MyAccountScreen(
                 modifier = Modifier.height(30.dp)
             )
         }
+    }
+
+    if (isShowLogoutDialog) {
+        RoomieTwoButtonDialog(
+            twoButtonDialogType = TwoButtonDialogType.LOGOUT,
+            onDismissRequest = updateLogoutDialog,
+            onClickDismiss = updateLogoutDialog,
+            onClickConfirm = deleteLogout
+        )
+    }
+
+    if (isShowWithdrawDialog) {
+        RoomieTwoButtonDialog(
+            twoButtonDialogType = TwoButtonDialogType.WITHDRAW,
+            onDismissRequest = updateWithdrawDialog,
+            onClickDismiss = updateWithdrawDialog,
+            onClickConfirm = deleteWithdraw
+        )
     }
 }
 
@@ -212,7 +239,11 @@ fun MyAccountScreenPreview() {
             navigateToGender = {},
             navigateToContact = {},
             deleteLogout = {},
-            deleteWithdraw = {}
+            deleteWithdraw = {},
+            isShowLogoutDialog = false,
+            isShowWithdrawDialog = false,
+            updateLogoutDialog = {},
+            updateWithdrawDialog = {},
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -1,6 +1,5 @@
 package com.wearerommies.roomie.presentation.ui.mypage.myaccount
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
@@ -31,6 +30,7 @@ import com.wearerommies.roomie.R
 import com.wearerommies.roomie.domain.entity.AccountEntity
 import com.wearerommies.roomie.presentation.core.component.RoomieButton
 import com.wearerommies.roomie.presentation.core.component.RoomieTwoButtonDialog
+import com.wearerommies.roomie.presentation.core.util.UserConstants.NO_DATA
 import com.wearerommies.roomie.presentation.core.util.formatGender
 import com.wearerommies.roomie.presentation.core.util.formatPhoneNumber
 import com.wearerommies.roomie.presentation.type.MyAccountType
@@ -95,7 +95,6 @@ fun MyAccountRoute(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MyAccountScreen(
     paddingValues: PaddingValues,
@@ -135,17 +134,17 @@ fun MyAccountScreen(
 
             MyAccountButton(
                 myAccountType = MyAccountType.NAME,
-                userInformation = state.name.orEmpty(),
+                userInformation = state.name ?: NO_DATA,
                 onClick = { navigateToName(state.name.orEmpty()) },
             )
             MyAccountButton(
                 myAccountType = MyAccountType.NICKNAME,
-                userInformation = state.nickname.orEmpty(),
+                userInformation = state.nickname ?: NO_DATA,
                 onClick = { navigateToNickname(state.nickname.orEmpty()) },
             )
             MyAccountButton(
                 myAccountType = MyAccountType.BIRTH,
-                userInformation = state.birthDate.orEmpty(),
+                userInformation = state.birthDate ?: NO_DATA,
                 onClick = { navigateToBirth(state.birthDate.orEmpty()) },
             )
             MyAccountButton(

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountSideEffect.kt
@@ -6,4 +6,5 @@ sealed class MyAccountSideEffect {
     data class NavigateToBirth(val birth: String) : MyAccountSideEffect()
     data class NavigateToGender(val gender: String) : MyAccountSideEffect()
     data class NavigateToContact(val contact: String) : MyAccountSideEffect()
+    data object NavigateToLogin : MyAccountSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountState.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountState.kt
@@ -10,5 +10,7 @@ data class MyAccountState(
         gender = "",
         name = "",
         phoneNumber = ""
-    )
+    ),
+    val isShowLogoutDialog: Boolean = false,
+    val isShowWithdrawDialog: Boolean = false,
 )

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
@@ -126,4 +126,16 @@ class MyAccountViewModel @Inject constructor(
     private fun navigateToLogin() = viewModelScope.launch {
         _sideEffect.emit(MyAccountSideEffect.NavigateToLogin)
     }
+
+    fun updateLogoutDialogState() = viewModelScope.launch {
+        _state.value = _state.value.copy(
+            isShowLogoutDialog = !_state.value.isShowLogoutDialog
+        )
+    }
+
+    fun updateWithdrawDialogState() = viewModelScope.launch {
+        _state.value = _state.value.copy(
+            isShowWithdrawDialog = !_state.value.isShowWithdrawDialog
+        )
+    }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
@@ -3,6 +3,8 @@ package com.wearerommies.roomie.presentation.ui.mypage.myaccount
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wearerommies.roomie.domain.entity.AccountEntity
+import com.wearerommies.roomie.domain.repository.AuthRepository
+import com.wearerommies.roomie.domain.repository.TokenRepository
 import com.wearerommies.roomie.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -18,6 +20,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MyAccountViewModel @Inject constructor(
     private val userRepository: UserRepository,
+    private val authRepository: AuthRepository,
+    private val tokenRepository: TokenRepository
 ) : ViewModel() {
     // state 관리
     private val _state = MutableStateFlow(MyAccountState())
@@ -43,6 +47,17 @@ class MyAccountViewModel @Inject constructor(
                     )
                 )
             }.onFailure { error ->
+                Timber.e(error)
+            }
+    }
+
+    fun deleteLogout() = viewModelScope.launch {
+        authRepository.deleteLogout(refreshToken = "Bearer ${tokenRepository.getRefreshToken()}")
+            .onSuccess {
+                tokenRepository.clearInfo()
+                navigateToLogin()
+            }
+            .onFailure { error ->
                 Timber.e(error)
             }
     }
@@ -95,5 +110,9 @@ class MyAccountViewModel @Inject constructor(
                 )
             )
         }
+    }
+
+    private fun navigateToLogin() = viewModelScope.launch {
+        _sideEffect.emit(MyAccountSideEffect.NavigateToLogin)
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
@@ -62,6 +62,17 @@ class MyAccountViewModel @Inject constructor(
             }
     }
 
+    fun deleteWithdraw() = viewModelScope.launch {
+        authRepository.deleteWithdraw(refreshToken = "Bearer ${tokenRepository.getRefreshToken()}")
+            .onSuccess {
+                tokenRepository.clearInfo()
+                navigateToLogin()
+            }
+            .onFailure { error ->
+                Timber.e(error)
+            }
+    }
+
     fun navigateToName(name: String) {
         viewModelScope.launch {
             _sideEffect.emit(

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/navigation/MyAccountNavigation.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/navigation/MyAccountNavigation.kt
@@ -23,6 +23,7 @@ fun NavGraphBuilder.myAccountNavGraph(
     navigateToBirth: (String) -> Unit,
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
+    navigateToLogin: () -> Unit,
 ) {
     composable<Route.MyAccount> {
         MyAccountRoute(
@@ -33,6 +34,7 @@ fun NavGraphBuilder.myAccountNavGraph(
             navigateToBirth = navigateToBirth,
             navigateToGender = navigateToGender,
             navigateToContact = navigateToContact,
+            navigateToLogin = navigateToLogin
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,7 +202,10 @@
     <string name="account_connect">계정 연동</string>
     <string name="kakaotalk">카카오톡</string>
     <string name="logout">로그아웃</string>
-    <string name="withdraw">탈퇴 하기</string>
+    <string name="logout_dialog_title">로그아웃 하시겠습니까?</string>
+    <string name="withdraw">탈퇴하기</string>
+    <string name="withdraw_dismiss">유지하기</string>
+    <string name="withdraw_dialog_title">회원 탈퇴 시, 고미와 찾았던\n셰어하우스는 모두 사라져요</string>
 
     // name
     <string name="name_edit">이름 수정하기</string>


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 이다루미!! -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **🏠 ISSUE**

- closed #148 

## **❗ WORK DESCRIPTION**

- 로그아웃, 회원탈퇴 api 연동
- RoomieDialog 구현
   - RoomieTwoButtonDialog 구현
- 계정 관리 다이얼로그 적용

## **📸 SCREENSHOT**

[logout.webm](https://github.com/user-attachments/assets/437f3cca-de95-4eaf-ae13-693039670fe7)

[withdraw.webm](https://github.com/user-attachments/assets/624cf2e9-8aee-4125-b881-1bc07f2558fd)

## **💻 주요 코드**

- 로그아웃, 회원탈퇴 api 연동하면서 아래처럼 스택을 관리해줬습니다! 자동로그인같은 경우도 고려해서 popUpTo(0)과 같이 스택을 모두 제거해주었습니다
```
fun navigateToLogin() {
        navController.navigateToLogin(
            navOptions = navOptions {
                popUpTo(0) {
                    inclusive = true
                }
                launchSingleTop = true
            }
        )
    }
```

## **📢 TO REVIEWERS**

- 덥다..
