### PR TITLE
[fix/#155] 카카오톡 채널 연결 오류 수정

### DIFF
--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
@@ -139,7 +139,6 @@ fun RoomieNavHost(
             navigateDetailRoom = navigator::navigateToDetailRoom,
             navigateDetailHouse = navigator::navigateToDetailHouse,
             navigateTourApply = navigator::navigateToTourFirstStep,
-            navigateToWebView = navigator::navigateToWebView
         )
         tourNavGraph(
             paddingValues = padding,

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailRoute.kt
@@ -88,7 +88,6 @@ fun DetailRoute(
     navigateDetailRoom: (Long, Long, String) -> Unit,
     navigateDetailHouse: (Long, String) -> Unit,
     navigateTourApply: (TourEntity, String, String) -> Unit,
-    navigateToWebView: (String) -> Unit,
     viewModel: DetailViewModel = hiltViewModel(),
 ) {
     val counter by remember { mutableIntStateOf(0) }
@@ -125,7 +124,6 @@ fun DetailRoute(
                     sideEffect.roomName
                 )
 
-                is DetailSideEffect.NavigateToWebView -> navigateToWebView(sideEffect.webViewUrl)
                 is DetailSideEffect.SnackBar -> {
                     snackBarHost.currentSnackbarData?.dismiss()
                     coroutineScope.launch {
@@ -157,7 +155,6 @@ fun DetailRoute(
         navigateDetailRoom = viewModel::navigateToDetail,
         navigateDetailHouse = viewModel::navigateToHouse,
         navigateTourApply = viewModel::navigateToTourApply,
-        navigateToWebView = viewModel::navigateToWebView,
         navigateToChannel = viewModel::navigateToChannel,
         state = state.uiState,
         isShowBottomSheet = state.isShowBottomSheet,
@@ -195,7 +192,6 @@ fun DetailScreen(
     navigateDetailRoom: (Long, Long, String) -> Unit,
     navigateDetailHouse: (Long, String) -> Unit,
     navigateTourApply: (Long, Long, String, String) -> Unit,
-    navigateToWebView: (String) -> Unit,
     navigateToChannel: () -> Unit,
     onLikeClick: (Long) -> Unit
 ) {
@@ -638,7 +634,6 @@ fun DetailScreenPreview() {
             updateSelecetedTourRoomId = {},
             selectedTourName = "",
             updateSelectedTourRoomName = {},
-            navigateToWebView = {},
             navigateToChannel = {},
             onLikeClick = {}
         )

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailRoute.kt
@@ -1,5 +1,8 @@
 package com.wearerommies.roomie.presentation.ui.detail
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -43,7 +46,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -62,7 +64,6 @@ import com.wearerommies.roomie.presentation.core.component.RoomieSnackbar
 import com.wearerommies.roomie.presentation.core.component.RoomieTopBar
 import com.wearerommies.roomie.presentation.core.extension.bottomBorder
 import com.wearerommies.roomie.presentation.core.extension.noRippleClickable
-import com.wearerommies.roomie.presentation.core.extension.roundedBackgroundWithBorder
 import com.wearerommies.roomie.presentation.core.extension.topBorder
 import com.wearerommies.roomie.presentation.core.util.PriceFormatter.formatPriceWon
 import com.wearerommies.roomie.presentation.core.util.UiState
@@ -73,7 +74,6 @@ import com.wearerommies.roomie.presentation.ui.detail.component.DetailContentHea
 import com.wearerommies.roomie.presentation.ui.detail.component.DetailInnerFacilityCard
 import com.wearerommies.roomie.presentation.ui.detail.component.DetailMoodCard
 import com.wearerommies.roomie.presentation.ui.detail.component.DetailRoomInfoCard
-import com.wearerommies.roomie.presentation.ui.detail.component.DetailRoomMateCard
 import com.wearerommies.roomie.presentation.ui.webview.WebViewUrl
 import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
 import com.wearerommies.roomie.ui.theme.RoomieTheme
@@ -135,6 +135,17 @@ fun DetailRoute(
                         )
                     }
                 }
+
+                is DetailSideEffect.NavigateToChannel -> {
+                    try {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(WebViewUrl.KAKAO_APP))
+                        context.startActivity(intent)
+                    } catch (e: ActivityNotFoundException) {
+                        val webIntent =
+                            Intent(Intent.ACTION_VIEW, Uri.parse(WebViewUrl.KAKAO_WEB))
+                        context.startActivity(webIntent)
+                    }
+                }
             }
         }
     }
@@ -147,6 +158,7 @@ fun DetailRoute(
         navigateDetailHouse = viewModel::navigateToHouse,
         navigateTourApply = viewModel::navigateToTourApply,
         navigateToWebView = viewModel::navigateToWebView,
+        navigateToChannel = viewModel::navigateToChannel,
         state = state.uiState,
         isShowBottomSheet = state.isShowBottomSheet,
         isLivingExpanded = state.isLivingExpanded,
@@ -184,6 +196,7 @@ fun DetailScreen(
     navigateDetailHouse: (Long, String) -> Unit,
     navigateTourApply: (Long, Long, String, String) -> Unit,
     navigateToWebView: (String) -> Unit,
+    navigateToChannel: () -> Unit,
     onLikeClick: (Long) -> Unit
 ) {
     val scrollState = rememberLazyListState()
@@ -510,7 +523,7 @@ fun DetailScreen(
                                 tint = RoomieTheme.colors.grayScale6
                             )
                         },
-                        onClickButton = { navigateToWebView(WebViewUrl.KAKAO) }
+                        onClickButton = navigateToChannel
                     )
                     RoomieButton(
                         text = stringResource(R.string.tour_apply_button),
@@ -626,6 +639,7 @@ fun DetailScreenPreview() {
             selectedTourName = "",
             updateSelectedTourRoomName = {},
             navigateToWebView = {},
+            navigateToChannel = {},
             onLikeClick = {}
         )
     }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailSideEffect.kt
@@ -27,4 +27,5 @@ sealed class DetailSideEffect {
     ) : DetailSideEffect()
 
     data class SnackBar(@StringRes val message: Int) : DetailSideEffect()
+    data object NavigateToChannel : DetailSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailSideEffect.kt
@@ -22,10 +22,6 @@ sealed class DetailSideEffect {
         val roomName: String
     ) : DetailSideEffect()
 
-    data class NavigateToWebView(
-        val webViewUrl: String
-    ) : DetailSideEffect()
-
     data class SnackBar(@StringRes val message: Int) : DetailSideEffect()
     data object NavigateToChannel : DetailSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailViewModel.kt
@@ -129,4 +129,8 @@ class DetailViewModel @Inject constructor(
                 Timber.e(error)
             }
     }
+
+    fun navigateToChannel() = viewModelScope.launch {
+        _sideEffect.emit(DetailSideEffect.NavigateToChannel)
+    }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/DetailViewModel.kt
@@ -109,10 +109,6 @@ class DetailViewModel @Inject constructor(
         )
     }
 
-    fun navigateToWebView(webViewUrl: String) = viewModelScope.launch {
-        _sideEffect.emit(DetailSideEffect.NavigateToWebView(webViewUrl = webViewUrl))
-    }
-
     fun bookmarkHouse(houseId: Long) = viewModelScope.launch {
         houseRepository.bookmarkHouse(houseId = houseId)
             .onSuccess { response ->

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/navigation/DetailNavigation.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/detail/navigation/DetailNavigation.kt
@@ -21,7 +21,11 @@ fun NavController.navigateToDetail(houseId: Long, navOptions: NavOptions? = null
     )
 }
 
-fun NavController.navigateToDetailHouse(houseId: Long, title: String, navOptions: NavOptions? = null) {
+fun NavController.navigateToDetailHouse(
+    houseId: Long,
+    title: String,
+    navOptions: NavOptions? = null
+) {
     navigate(
         route = Route.DetailHouse(
             houseId = houseId,
@@ -31,7 +35,12 @@ fun NavController.navigateToDetailHouse(houseId: Long, title: String, navOptions
     )
 }
 
-fun NavController.navigateToDetailRoom(houseId: Long, roomId: Long, title: String, navOptions: NavOptions? = null) {
+fun NavController.navigateToDetailRoom(
+    houseId: Long,
+    roomId: Long,
+    title: String,
+    navOptions: NavOptions? = null
+) {
     navigate(
         route = Route.DetailRoom(
             houseId = houseId,
@@ -48,8 +57,7 @@ fun NavGraphBuilder.detailNavGraph(
     navigateDetailRoom: (Long, Long, String) -> Unit,
     navigateDetailHouse: (Long, String) -> Unit,
     navigateTourApply: (TourEntity, String, String) -> Unit,
-    navigateToWebView: (String) -> Unit,
-    ) {
+) {
     composable<Route.Detail> { backStackEntry ->
         val houseId = backStackEntry.toRoute<Route.Detail>().houseId
         DetailRoute(
@@ -59,7 +67,6 @@ fun NavGraphBuilder.detailNavGraph(
             navigateDetailRoom = navigateDetailRoom,
             navigateDetailHouse = navigateDetailHouse,
             navigateTourApply = navigateTourApply,
-            navigateToWebView = navigateToWebView
         )
     }
     composable<Route.DetailHouse> { backStackEntry ->
@@ -77,12 +84,12 @@ fun NavGraphBuilder.detailNavGraph(
         val houseId = backStackEntry.toRoute<Route.DetailRoom>().houseId
         val roomId = backStackEntry.toRoute<Route.DetailRoom>().roomId
         val title = backStackEntry.toRoute<Route.DetailRoom>().title
-            DetailRoomRoute(
-                paddingValues = paddingValues,
-                houseId = houseId,
-                roomId = roomId,
-                title = title,
-                navigateUp = navigateUp,
-            )
+        DetailRoomRoute(
+            paddingValues = paddingValues,
+            houseId = houseId,
+            roomId = roomId,
+            title = title,
+            navigateUp = navigateUp,
+        )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyRoute.kt
@@ -1,5 +1,8 @@
 package com.wearerommies.roomie.presentation.ui.mypage.my
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -69,6 +72,16 @@ fun MyRoute(
                     is MySideEffect.NavigateToBookMark -> navigateToBookmark()
                     is MySideEffect.NavigateToMyAccount -> navigateToMyAccount()
                     is MySideEffect.NavigateToWebView -> navigateToWebView(sideEffect.webViewUrl)
+                    is MySideEffect.NavigateToChannel -> {
+                        try {
+                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(WebViewUrl.KAKAO_APP))
+                            context.startActivity(intent)
+                        } catch (e: ActivityNotFoundException) {
+                            val webIntent =
+                                Intent(Intent.ACTION_VIEW, Uri.parse(WebViewUrl.KAKAO_WEB))
+                            context.startActivity(webIntent)
+                        }
+                    }
                 }
             }
     }
@@ -79,6 +92,7 @@ fun MyRoute(
         navigateToMyAccount = viewModel::navigateToMyAccount,
         navigateToBookmark = viewModel::navigateToBookmark,
         navigateToWebView = viewModel::navigateToWebView,
+        navigateToChannel = viewModel::navigateToChannel,
         state = state.uiState
     )
 
@@ -91,6 +105,7 @@ fun MyScreen(
     navigateToMyAccount: () -> Unit,
     navigateToBookmark: () -> Unit,
     navigateToWebView: (String) -> Unit,
+    navigateToChannel: () -> Unit,
     state: MyPageEntity,
     modifier: Modifier = Modifier
 ) {
@@ -157,7 +172,7 @@ fun MyScreen(
             MyButtonWithHelperText(
                 mainText = stringResource(R.string.add_new_room),
                 helperText = stringResource(R.string.register_sharehouse_owner),
-                onClick = { navigateToWebView(WebViewUrl.KAKAO) }
+                onClick = navigateToChannel
             )
 
             RoomieNavigateButton(
@@ -199,6 +214,7 @@ fun MyScreenPreview() {
             navigateToMyAccount = {},
             navigateToBookmark = {},
             navigateToWebView = {},
+            navigateToChannel = {},
             state = MyPageEntity(
                 nickname = "루미",
                 socialType = "KAKAO"

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MySideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MySideEffect.kt
@@ -7,4 +7,5 @@ sealed class MySideEffect {
     data class NavigateToWebView(
         val webViewUrl: String
     ) : MySideEffect()
+    data object NavigateToChannel: MySideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/my/MyViewModel.kt
@@ -58,4 +58,8 @@ class MyViewModel @Inject constructor(
     fun navigateToWebView(webViewUrl: String) = viewModelScope.launch {
         _sideEffect.emit(MySideEffect.NavigateToWebView(webViewUrl = webViewUrl))
     }
+
+    fun navigateToChannel() = viewModelScope.launch {
+        _sideEffect.emit(MySideEffect.NavigateToChannel)
+    }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/webview/WebViewRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/webview/WebViewRoute.kt
@@ -8,7 +8,8 @@ import com.wearerommies.roomie.ui.theme.RoomieAndroidTheme
 
 object WebViewUrl {
     const val QUIZ = "https://smore.im/quiz/mDC9DH57g2"
-    const val KAKAO = "https://pf.kakao.com/_WviTn"
+    const val KAKAO_APP = "kakaoplus://plusfriend/friend/_WviTn"
+    const val KAKAO_WEB = "https://pf.kakao.com/_WviTn"
     const val SEARCH = "https://tally.so/r/3y8ygX"
     const val FEEDBACK = "https://tally.so/r/megeRl"
     const val SERVICE = "https://automatic-protocol-11a.notion.site/23336a29f06280a394ceea5f51b2d09b"


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 이다루미!! -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **🏠 ISSUE**

- closed #155 

## **❗ WORK DESCRIPTION**

- 카카오톡 채널 연결 오류를 수정했습니다.
  - 마이페이지 매물 등록하기 버튼
  - 매물 상세 페이지 채팅 버튼

## **📸 SCREENSHOT**

- 웹으로 이동

https://github.com/user-attachments/assets/ebf73aed-6884-4ca0-a1db-30e8708992c9

- 앱으로 이동 (매물 상세 페이지)

https://github.com/user-attachments/assets/bbb0e2e6-d85b-4e0e-b145-69ad4761006d


- 앱으로 이동 (마이 페이지)

https://github.com/user-attachments/assets/cb9828df-f367-47ca-8e83-b20d24144f77


## **💻 주요 코드**

먼저 코드는 아래와 같습니다.

```
try {
        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(WebViewUrl.KAKAO_APP)) // 카카오톡이 설치되어 있는 경우
                        context.startActivity(intent)
      } catch (e: ActivityNotFoundException) {
                        val webIntent =
                            Intent(Intent.ACTION_VIEW, Uri.parse(WebViewUrl.KAKAO_WEB)) // 설치되어 있지 않으면 웹으로 이동
                        context.startActivity(webIntent)
      }
```
카카오톡이 설치되어있다면 위의 영상처럼 카카오톡을 통해 채널로 이동합니다. 
그렇지 않다면 웹으로 이동합니다. 웹으로 이동한 경우에도 채팅 버튼을 누르면 카카오톡 설치가 필요합니다. 설치하기 버튼을 누르는 경우, 구글플레이스토어 카카오톡 설치 화면으로 넘어갑니다.

## **📢 TO REVIEWERS**

- 천둥번개 소리를 asmr 삼아..
