### PR TITLE
[Feature/#159] 자체 QA 수정

### DIFF
--- a/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieRoomCard.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/core/component/RoomieRoomCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -175,7 +176,9 @@ private fun DotWithText(
         Text(
             text = firstText,
             style = RoomieTheme.typography.body4R12,
-            color = RoomieTheme.colors.grayScale7
+            color = RoomieTheme.colors.grayScale7,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_middle_dot),
@@ -185,7 +188,9 @@ private fun DotWithText(
         Text(
             text = secondText,
             style = RoomieTheme.typography.body4R12,
-            color = RoomieTheme.colors.grayScale7
+            color = RoomieTheme.colors.grayScale7,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainNavigator.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/MainNavigator.kt
@@ -86,7 +86,7 @@ class MainNavigator(
     fun navigateToOnboarding() {
         navController.navigateToOnboarding(
             navOptions = navOptions {
-                popUpTo(navController.graph.findStartDestination().id) {
+                popUpTo(0) {
                     inclusive = true
                 }
                 launchSingleTop = true

--- a/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/navigator/component/RoomieNavHost.kt
@@ -91,7 +91,7 @@ fun RoomieNavHost(
             navigateToBirth = navigator::navigateToBirth,
             navigateToGender = navigator::navigateToGender,
             navigateToContact = navigator::navigateToContact,
-            navigateToLogin = navigator::navigateToLogin
+            navigateToOnboarding = navigator::navigateToOnboarding
         )
         nameNavGraph(
             paddingValues = padding,
@@ -146,7 +146,8 @@ fun RoomieNavHost(
             navigateToSecondStep = navigator::navigateToTourSecondStep,
             navigateToThirdStep = navigator::navigateToTourThirdStep,
             navigateToCompleteStep = navigator::navigateToCompleteStep,
-            navigateToHome = navigator::navigateToHome
+            navigateToHome = navigator::navigateToHome,
+            navigateToMap = { navigator.navigate(tab = MainTabType.MAP) }
         )
         webViewNavGraph(
             paddingValues = padding,

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountRoute.kt
@@ -49,7 +49,7 @@ fun MyAccountRoute(
     navigateToBirth: (String) -> Unit,
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
-    navigateToLogin: () -> Unit,
+    navigateToOnboarding: () -> Unit,
     viewModel: MyAccountViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -72,7 +72,7 @@ fun MyAccountRoute(
                     is MyAccountSideEffect.NavigateToContact -> navigateToContact(sideEffect.contact)
                     is MyAccountSideEffect.NavigateToGender -> navigateToGender(sideEffect.gender)
                     is MyAccountSideEffect.NavigateToName -> navigateToName(sideEffect.name)
-                    is MyAccountSideEffect.NavigateToLogin -> navigateToLogin()
+                    is MyAccountSideEffect.NavigateToOnboarding -> navigateToOnboarding()
                 }
             }
     }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountSideEffect.kt
@@ -6,5 +6,5 @@ sealed class MyAccountSideEffect {
     data class NavigateToBirth(val birth: String) : MyAccountSideEffect()
     data class NavigateToGender(val gender: String) : MyAccountSideEffect()
     data class NavigateToContact(val contact: String) : MyAccountSideEffect()
-    data object NavigateToLogin : MyAccountSideEffect()
+    data object NavigateToOnboarding : MyAccountSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/MyAccountViewModel.kt
@@ -55,7 +55,7 @@ class MyAccountViewModel @Inject constructor(
         authRepository.deleteLogout(refreshToken = "Bearer ${tokenRepository.getRefreshToken()}")
             .onSuccess {
                 tokenRepository.clearInfo()
-                navigateToLogin()
+                navigateToOnboarding()
             }
             .onFailure { error ->
                 Timber.e(error)
@@ -66,7 +66,7 @@ class MyAccountViewModel @Inject constructor(
         authRepository.deleteWithdraw(refreshToken = "Bearer ${tokenRepository.getRefreshToken()}")
             .onSuccess {
                 tokenRepository.clearInfo()
-                navigateToLogin()
+                navigateToOnboarding()
             }
             .onFailure { error ->
                 Timber.e(error)
@@ -123,8 +123,8 @@ class MyAccountViewModel @Inject constructor(
         }
     }
 
-    private fun navigateToLogin() = viewModelScope.launch {
-        _sideEffect.emit(MyAccountSideEffect.NavigateToLogin)
+    private fun navigateToOnboarding() = viewModelScope.launch {
+        _sideEffect.emit(MyAccountSideEffect.NavigateToOnboarding)
     }
 
     fun updateLogoutDialogState() = viewModelScope.launch {

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/navigation/MyAccountNavigation.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/mypage/myaccount/navigation/MyAccountNavigation.kt
@@ -23,7 +23,7 @@ fun NavGraphBuilder.myAccountNavGraph(
     navigateToBirth: (String) -> Unit,
     navigateToGender: (String) -> Unit,
     navigateToContact: (String) -> Unit,
-    navigateToLogin: () -> Unit,
+    navigateToOnboarding: () -> Unit,
 ) {
     composable<Route.MyAccount> {
         MyAccountRoute(
@@ -34,7 +34,7 @@ fun NavGraphBuilder.myAccountNavGraph(
             navigateToBirth = navigateToBirth,
             navigateToGender = navigateToGender,
             navigateToContact = navigateToContact,
-            navigateToLogin = navigateToLogin
+            navigateToOnboarding = navigateToOnboarding
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/completed/TourCompletedSideEffect.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/completed/TourCompletedSideEffect.kt
@@ -1,6 +1,7 @@
 package com.wearerommies.roomie.presentation.ui.tour.completed
 
 sealed class TourCompletedSideEffect {
-    data object NavigateUp: TourCompletedSideEffect()
-    data object NavigateToHome: TourCompletedSideEffect()
+    data object NavigateUp : TourCompletedSideEffect()
+    data object NavigateToHome : TourCompletedSideEffect()
+    data object NavigateToMap : TourCompletedSideEffect()
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/completed/TourCompletedStepRoute.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/completed/TourCompletedStepRoute.kt
@@ -32,6 +32,7 @@ import com.wearerommies.roomie.ui.theme.RoomieTheme
 fun TourCompletedStepRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
+    navigateToMap: () -> Unit,
     navigateToHome: () -> Unit,
     viewModel: TourCompletedStepViewModel = hiltViewModel()
 ) {
@@ -40,7 +41,10 @@ fun TourCompletedStepRoute(
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is TourCompletedSideEffect.NavigateUp -> navigateUp()
+                TourCompletedSideEffect.NavigateUp -> navigateUp()
+
+                is TourCompletedSideEffect.NavigateToMap -> navigateToMap()
+
                 is TourCompletedSideEffect.NavigateToHome -> navigateToHome()
             }
         }
@@ -50,6 +54,7 @@ fun TourCompletedStepRoute(
         paddingValues = paddingValues,
         navigateUp = viewModel::navigateUp,
         navigateToHome = viewModel::navigateHome,
+        navigateToMap = viewModel::navigateToMap
     )
 }
 
@@ -58,6 +63,7 @@ fun TourCompletedStepScreen(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
     navigateToHome: () -> Unit,
+    navigateToMap: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -68,7 +74,7 @@ fun TourCompletedStepScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 
-        Spacer(modifier=Modifier.height((LocalConfiguration.current.screenHeightDp * 0.235).dp))
+        Spacer(modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.235).dp))
 
         Text(
             text = stringResource(R.string.tour_apply_complete),
@@ -107,7 +113,7 @@ fun TourCompletedStepScreen(
                 text = stringResource(R.string.tour_other_room),
                 backgroundColor = RoomieTheme.colors.grayScale1,
                 textColor = RoomieTheme.colors.grayScale8,
-                onClick = navigateUp,
+                onClick = navigateToMap,
                 modifier = Modifier
                     .weight(0.4613F),
                 borderColor = RoomieTheme.colors.grayScale6,
@@ -134,7 +140,8 @@ fun TourCompletedStepScreenPreview() {
         TourCompletedStepScreen(
             paddingValues = PaddingValues(0.dp),
             navigateUp = {},
-            navigateToHome = {}
+            navigateToHome = {},
+            navigateToMap = {}
         )
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/completed/TourCompletedStepViewModel.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/completed/TourCompletedStepViewModel.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class TourCompletedStepViewModel@Inject constructor(
+class TourCompletedStepViewModel @Inject constructor(
 
-): ViewModel() {
+) : ViewModel() {
     private val _sideEffect = MutableSharedFlow<TourCompletedSideEffect>()
     val sideEffect: SharedFlow<TourCompletedSideEffect>
         get() = _sideEffect.asSharedFlow()
@@ -21,5 +21,9 @@ class TourCompletedStepViewModel@Inject constructor(
 
     fun navigateHome() = viewModelScope.launch {
         _sideEffect.emit(TourCompletedSideEffect.NavigateToHome)
+    }
+
+    fun navigateToMap() = viewModelScope.launch {
+        _sideEffect.emit(TourCompletedSideEffect.NavigateToMap)
     }
 }

--- a/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/navigation/TourNavigation.kt
+++ b/app/src/main/java/com/wearerommies/roomie/presentation/ui/tour/navigation/TourNavigation.kt
@@ -13,7 +13,12 @@ import com.wearerommies.roomie.presentation.ui.tour.first.TourFirstStepRoute
 import com.wearerommies.roomie.presentation.ui.tour.second.TourSecondStepRoute
 import com.wearerommies.roomie.presentation.ui.tour.third.TourThirdStepRoute
 
-fun NavController.navigateToTourFirstStep(tourApply: TourEntity, houseName: String, roomName: String, navOptions: NavOptions? = null) {
+fun NavController.navigateToTourFirstStep(
+    tourApply: TourEntity,
+    houseName: String,
+    roomName: String,
+    navOptions: NavOptions? = null
+) {
     navigate(
         route = Route.TourFirstStep(
             tourApply = tourApply,
@@ -56,12 +61,13 @@ fun NavGraphBuilder.tourNavGraph(
     navigateToSecondStep: (TourEntity) -> Unit,
     navigateToThirdStep: (TourEntity) -> Unit,
     navigateToCompleteStep: () -> Unit,
-    navigateToHome: () -> Unit
+    navigateToHome: () -> Unit,
+    navigateToMap: () -> Unit
 ) {
 
-    composable<Route.TourFirstStep> (
+    composable<Route.TourFirstStep>(
         typeMap = Route.TourFirstStep.typeMap
-    ){ backStackEntry ->
+    ) { backStackEntry ->
         TourFirstStepRoute(
             paddingValues = paddingValues,
             navigateUp = navigateUp,
@@ -101,6 +107,7 @@ fun NavGraphBuilder.tourNavGraph(
         TourCompletedStepRoute(
             paddingValues = paddingValues,
             navigateUp = navigateUp,
+            navigateToMap = navigateToMap,
             navigateToHome = navigateToHome
         )
     }


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 이다루미!! -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **🏠 ISSUE**

- closed #159

## **❗ WORK DESCRIPTION**

- 안드로이드 자체 QA 를 진행했습니다
- 분위기별 매물 카드 레이아웃
- 로그아웃 버튼 -> 로그인 페이지X, 온보딩으로 화면 넘어가도록 (스택 지움)
- 다른 방 보러가기 버튼 -> 상세 매물 페이지X,지도 페이지로 이동

## **📸 SCREENSHOT**

<!----필요한 친구들로 골라쓰루미!-->
<!---- <video src="" width="300" /> -->
<!---- <img src="" width="300" /> -->
<!----Before | After
  :--: | :--:
  <img src="" width="300" /> | <img src="" width="300" >-->

## **💻 주요 코드**


## **📢 TO REVIEWERS**

- delegate so sorry 했습니다 ㅎㅎㅎ!!!!